### PR TITLE
Rename dup test names by adding Rdd/SqlContext/DataFrame for clarity.

### DIFF
--- a/csharp/AdapterTest/DataFrameTest.cs
+++ b/csharp/AdapterTest/DataFrameTest.cs
@@ -18,7 +18,7 @@ namespace AdapterTest
         //TODO - complete impl
 
         [TestMethod]
-        public void TestJoin()
+        public void TestDataFrameJoin()
         {
             var sqlContext = new SqlContext(new SparkContext("", ""));
             var dataFrame = sqlContext.JsonFile(@"c:\path\to\input.json"); 

--- a/csharp/AdapterTest/RDDTest.cs
+++ b/csharp/AdapterTest/RDDTest.cs
@@ -19,7 +19,7 @@ namespace AdapterTest
         //TODO - complete impl
 
         [TestMethod]
-        public void TestMap()
+        public void TestRddMap()
         {
             var sparkContext = new SparkContext(null);
             var rdd = sparkContext.TextFile(@"c:\path\to\rddinput.txt");
@@ -39,7 +39,7 @@ namespace AdapterTest
         }
 
         [TestMethod]
-        public void TestTextFile()
+        public void TestRddTextFile()
         {
             var sparkContext = new SparkContext(null);
             var rdd = sparkContext.TextFile(@"c:\path\to\rddinput.txt");
@@ -49,7 +49,7 @@ namespace AdapterTest
         }
 
         [TestMethod]
-        public void TestUnion()
+        public void TestRddUnion()
         {
             var sparkContext = new SparkContext(null);
             var rdd = sparkContext.TextFile(@"c:\path\to\rddinput.txt"); 

--- a/csharp/AdapterTest/SqlContextTest.cs
+++ b/csharp/AdapterTest/SqlContextTest.cs
@@ -27,7 +27,7 @@ namespace AdapterTest
         }
 
         [TestMethod]
-        public void TestJsonFile()
+        public void TestSqlContextJsonFile()
         {
             var sqlContext = new SqlContext(new SparkContext("", "")); 
             var dataFrame = sqlContext.JsonFile(@"c:\path\to\input.json");
@@ -36,7 +36,7 @@ namespace AdapterTest
         }
 
         [TestMethod]
-        public void TestTextFile()
+        public void TestSqlContextTextFile()
         {
             var sqlContext = new SqlContext(new SparkContext("", ""));
             var dataFrame = sqlContext.TextFile(@"c:\path\to\input.txt");


### PR DESCRIPTION
- Several test cases have same names but in different namespaces, but FQN does not show in many test runners like Visual Studio.

- Added `Rdd` or `SqlContext` or `DataFrame` into the test name as appropriate, for disambiguation.