### PR TITLE
SparkCLR.nuspec file

### DIFF
--- a/csharp/SparkCLR.nuspec
+++ b/csharp/SparkCLR.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.SparkCLR</id>
+    <version>1.0.0</version>
+    <authors>Microsoft Corporation</authors>
+    <owners>Microsoft Corporation</owners>
+    <licenseUrl>https://github.com/Microsoft/SparkCLR/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/SparkCLR</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>C# language binding and extensions to Apache Spark</description>
+    <releaseNotes>See release notes on GitHub https://github.com/Microsoft/SparkCLR/releases</releaseNotes>
+    <copyright>Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.</copyright>
+    <tags>C# .NET Apache Spark RDD DataFrame</tags>
+    <dependencies>
+      <dependency id="Razorvine.Pyrolite" version="4.10.0.0" />
+      <dependency id="Razorvine.Serpent" version="1.12.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Adapter\Microsoft.Spark.CSharp\bin\Release\Microsoft.Spark.CSharp.Adapter.dll" target="lib\net45" />
+    <file src="Worker\Microsoft.Spark.CSharp\bin\Release\CSharpWorker.exe" target="lib\net45" />
+  </files>
+</package>


### PR DESCRIPTION
Separate copy of SparkCLR.nuspec file
- Split out SparkCLR.nuspec from PR #6 commit 6e87a820e60f6337bd1adfe08c7e3dc90988644b

Some outstanding questions still to be worked out wrt the correct contents of the .nuspec file:

@skaarthik  wrote:

``` xml
<requireLicenseAcceptance>false</requireLicenseAcceptance>
```
> I will get back to this PR after learning more about this tag in the context of this project

