### PR TITLE
Fix minor issues in code-docs

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Spark.CSharp.Configuration
 
             internal virtual string GetCSharpRDDExternalProcessName()
             {
-                //SparkCLR jar and driver, worker & dependencies are shipped using Spark file server. Thse files available in spark executing directory at executor
+                //SparkCLR jar and driver, worker & dependencies are shipped using Spark file server. These files available in spark executing directory at executor
                 return "CSharpWorker.exe";
             }
 

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/DoubleRDDFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/DoubleRDDFunctions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// Compute a histogram using the provided buckets. The buckets
         /// are all open to the right except for the last which is closed.
         /// e.g. [1,10,20,50] means the buckets are [1,10) [10,20) [20,50],
-        /// which means 1<=x<10, 10<=x<20, 20<=x<=50. And on the input of 1
+        /// which means 1&lt;=x&lt;10, 10&lt;=x&lt;20, 20&lt;=x&lt;=50. And on the input of 1
         /// and 50 we would have a histogram of 1,0,1.
         /// 
         /// If your histogram is evenly spaced (e.g. [0, 10, 20, 30]),
@@ -73,6 +73,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// 
         /// </summary>
         /// <param name="self"></param>
+        /// <param name="bucketCount"></param>
         /// <returns></returns>
         public static Tuple<double[], long[]> Histogram(this RDD<double> self, int bucketCount)
         {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/PairRDDFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/PairRDDFunctions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Return the key-value pairs in this RDD to the master as a dictionary.
         ///
-        /// var m = sc.Parallelize(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(3, 4) }, 1).CollectAsMap()
+        /// var m = sc.Parallelize(new[] { new KeyValuePair&lt;int, int>(1, 2), new KeyValuePair&lt;int, int>(3, 4) }, 1).CollectAsMap()
         /// m[1]
         /// 2
         /// m[3]
@@ -45,7 +45,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Return an RDD with the keys of each tuple.
         ///
-        /// >>> m = sc.Parallelize(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(3, 4) }, 1).Keys().Collect()
+        /// >>> m = sc.Parallelize(new[] { new KeyValuePair&lt;int, int>(1, 2), new KeyValuePair&lt;int, int>(3, 4) }, 1).Keys().Collect()
         /// [1, 3]
         /// </summary>
         /// <typeparam name="K"></typeparam>
@@ -60,7 +60,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Return an RDD with the values of each tuple.
         ///
-        /// >>> m = sc.Parallelize(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(3, 4) }, 1).Values().Collect()
+        /// >>> m = sc.Parallelize(new[] { new KeyValuePair&lt;int, int>(1, 2), new KeyValuePair&lt;int, int>(3, 4) }, 1).Values().Collect()
         /// [2, 4]
         /// 
         /// </summary>
@@ -84,9 +84,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// 
         /// sc.Parallelize(new[] 
         /// { 
-        ///     new KeyValuePair<string, int>("a", 1), 
-        ///     new KeyValuePair<string, int>("b", 1),
-        ///     new KeyValuePair<string, int>("a", 1)
+        ///     new KeyValuePair&lt;string, int>("a", 1), 
+        ///     new KeyValuePair&lt;string, int>("b", 1),
+        ///     new KeyValuePair&lt;string, int>("a", 1)
         /// }, 2)
         /// .ReduceByKey((x, y) => x + y).Collect()
         ///        
@@ -97,6 +97,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <typeparam name="V"></typeparam>
         /// <param name="self"></param>
         /// <param name="reduceFunc"></param>
+        /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static RDD<KeyValuePair<K, V>> ReduceByKey<K, V>(this RDD<KeyValuePair<K, V>> self, Func<V, V, V> reduceFunc, int numPartitions = 0)
         {
@@ -112,9 +113,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// 
         /// sc.Parallelize(new[] 
         /// { 
-        ///     new KeyValuePair<string, int>("a", 1), 
-        ///     new KeyValuePair<string, int>("b", 1),
-        ///     new KeyValuePair<string, int>("a", 1)
+        ///     new KeyValuePair&lt;string, int>("a", 1), 
+        ///     new KeyValuePair&lt;string, int>("b", 1),
+        ///     new KeyValuePair&lt;string, int>("a", 1)
         /// }, 2)
         /// .ReduceByKeyLocally((x, y) => x + y).Collect()
         /// 
@@ -136,9 +137,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// 
         /// sc.Parallelize(new[] 
         /// { 
-        ///     new KeyValuePair<string, int>("a", 1), 
-        ///     new KeyValuePair<string, int>("b", 1),
-        ///     new KeyValuePair<string, int>("a", 1)
+        ///     new KeyValuePair&lt;string, int>("a", 1), 
+        ///     new KeyValuePair&lt;string, int>("b", 1),
+        ///     new KeyValuePair&lt;string, int>("a", 1)
         /// }, 2)
         /// .CountByKey((x, y) => x + y).Collect()
         /// 
@@ -162,9 +163,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// Performs a hash join across the cluster.
         /// 
         /// var l = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 1);
         /// var r = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 2), new KeyValuePair<string, int>("a", 3) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 2), new KeyValuePair&lt;string, int>("a", 3) }, 1);
         /// var m = l.Join(r, 2).Collect();
         /// 
         /// [('a', (1, 2)), ('a', (1, 3))]
@@ -197,9 +198,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// Hash-partitions the resulting RDD into the given number of partitions.
         /// 
         /// var l = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 1);
         /// var r = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 2) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 2) }, 1);
         /// var m = l.LeftOuterJoin(r).Collect();
         /// 
         /// [('a', (1, 2)), ('b', (4, None))]
@@ -231,9 +232,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// Hash-partitions the resulting RDD into the given number of partitions.
         /// 
         /// var l = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 2) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 2) }, 1);
         /// var r = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 1);
         /// var m = l.RightOuterJoin(r).Collect();
         /// 
         /// [('a', (2, 1)), ('b', (None, 4))]
@@ -269,9 +270,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// Hash-partitions the resulting RDD into the given number of partitions.
         /// 
         /// var l = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 1);
         /// var r = sc.Parallelize(
-        ///     new[] { new KeyValuePair<string, int>("a", 2), new KeyValuePair<string, int>("c", 8) }, 1);
+        ///     new[] { new KeyValuePair&lt;string, int>("a", 2), new KeyValuePair&lt;string, int>("c", 8) }, 1);
         /// var m = l.FullOuterJoin(r).Collect();
         /// 
         /// [('a', (1, 2)), ('b', (4, None)), ('c', (None, 8))]
@@ -297,8 +298,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Return a copy of the RDD partitioned using the specified partitioner.
         /// 
-        /// sc.Parallelize(new[] { 1, 2, 3, 4, 2, 4, 1 }, 1).Map(x => new KeyValuePair<int, int>(x, x)).PartitionBy(3).Glom().Collect()
+        /// sc.Parallelize(new[] { 1, 2, 3, 4, 2, 4, 1 }, 1).Map(x => new KeyValuePair&lt;int, int>(x, x)).PartitionBy(3).Glom().Collect()
         /// </summary>
+        /// <param name="self"></param>
         /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static RDD<KeyValuePair<K, V>> PartitionBy<K, V>(this RDD<KeyValuePair<K, V>> self, int numPartitions = 0)
@@ -342,9 +344,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// sc.Parallelize(
         ///         new[] 
         ///         { 
-        ///             new KeyValuePair<string, int>("a", 1), 
-        ///             new KeyValuePair<string, int>("b", 1),
-        ///             new KeyValuePair<string, int>("a", 1)
+        ///             new KeyValuePair&lt;string, int>("a", 1), 
+        ///             new KeyValuePair&lt;string, int>("b", 1),
+        ///             new KeyValuePair&lt;string, int>("a", 1)
         ///         }, 2)
         ///         .CombineByKey(() => string.Empty, (x, y) => x + y.ToString(), (x, y) => x + y).Collect()
         ///         
@@ -352,7 +354,11 @@ namespace Microsoft.Spark.CSharp.Core
         /// </summary>
         /// <typeparam name="K"></typeparam>
         /// <typeparam name="V"></typeparam>
+        /// <typeparam name="C"></typeparam>
         /// <param name="self"></param>
+        /// <param name="createCombiner"></param>
+        /// <param name="mergeValue"></param>
+        /// <param name="mergeCombiners"></param>
         /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static RDD<KeyValuePair<K, C>> CombineByKey<K, V, C>(
@@ -388,9 +394,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// sc.Parallelize(
         ///         new[] 
         ///         { 
-        ///             new KeyValuePair<string, int>("a", 1), 
-        ///             new KeyValuePair<string, int>("b", 1),
-        ///             new KeyValuePair<string, int>("a", 1)
+        ///             new KeyValuePair&lt;string, int>("a", 1), 
+        ///             new KeyValuePair&lt;string, int>("b", 1),
+        ///             new KeyValuePair&lt;string, int>("a", 1)
         ///         }, 2)
         ///         .CombineByKey(() => string.Empty, (x, y) => x + y.ToString(), (x, y) => x + y).Collect()
         ///         
@@ -424,9 +430,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// sc.Parallelize(
         ///         new[] 
         ///         { 
-        ///             new KeyValuePair<string, int>("a", 1), 
-        ///             new KeyValuePair<string, int>("b", 1),
-        ///             new KeyValuePair<string, int>("a", 1)
+        ///             new KeyValuePair&lt;string, int>("a", 1), 
+        ///             new KeyValuePair&lt;string, int>("b", 1),
+        ///             new KeyValuePair&lt;string, int>("a", 1)
         ///         }, 2)
         ///         .CombineByKey(() => string.Empty, (x, y) => x + y.ToString(), (x, y) => x + y).Collect()
         ///         
@@ -459,9 +465,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// sc.Parallelize(
         ///         new[] 
         ///         { 
-        ///             new KeyValuePair<string, int>("a", 1), 
-        ///             new KeyValuePair<string, int>("b", 1),
-        ///             new KeyValuePair<string, int>("a", 1)
+        ///             new KeyValuePair&lt;string, int>("a", 1), 
+        ///             new KeyValuePair&lt;string, int>("b", 1),
+        ///             new KeyValuePair&lt;string, int>("a", 1)
         ///         }, 2)
         ///         .GroupByKey().MapValues(l => string.Join(" ", l)).Collect()
         ///         
@@ -489,8 +495,8 @@ namespace Microsoft.Spark.CSharp.Core
         /// sc.Parallelize(
         ///         new[] 
         ///         { 
-        ///             new KeyValuePair<string, string[]>("a", new[]{"apple", "banana", "lemon"}), 
-        ///             new KeyValuePair<string, string[]>("b", new[]{"grapes"})
+        ///             new KeyValuePair&lt;string, string[]>("a", new[]{"apple", "banana", "lemon"}), 
+        ///             new KeyValuePair&lt;string, string[]>("b", new[]{"grapes"})
         ///         }, 2)
         ///         .MapValues(x => x.Length).Collect()
         ///         
@@ -515,8 +521,8 @@ namespace Microsoft.Spark.CSharp.Core
         /// x = sc.Parallelize(
         ///         new[] 
         ///         { 
-        ///             new KeyValuePair<string, string[]>("a", new[]{"x", "y", "z"}), 
-        ///             new KeyValuePair<string, string[]>("b", new[]{"p", "r"})
+        ///             new KeyValuePair&lt;string, string[]>("a", new[]{"x", "y", "z"}), 
+        ///             new KeyValuePair&lt;string, string[]>("b", new[]{"p", "r"})
         ///         }, 2)
         ///         .FlatMapValues(x => x).Collect()
         ///         
@@ -538,8 +544,8 @@ namespace Microsoft.Spark.CSharp.Core
         /// For each key k in C{self} or C{other}, return a resulting RDD that
         /// contains a tuple with the list of values for that key in C{self} as well as C{other}.
         /// 
-        /// var x = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 2);
-        /// var y = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 2) }, 1);
+        /// var x = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 2);
+        /// var y = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 2) }, 1);
         /// x.GroupWith(y).Collect();
         /// 
         /// [('a', ([1], [2])), ('b', ([4], []))]
@@ -550,6 +556,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <typeparam name="W"></typeparam>
         /// <param name="self"></param>
         /// <param name="other"></param>
+        /// <param name="numPartitions"></param>
         /// <returns></returns>
         public static RDD<KeyValuePair<K, Tuple<List<V>, List<W>>>> GroupWith<K, V, W>(
             this RDD<KeyValuePair<K, V>> self,
@@ -566,9 +573,9 @@ namespace Microsoft.Spark.CSharp.Core
         }
 
         /// <summary>
-        /// var x = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 5), new KeyValuePair<string, int>("b", 6) }, 2);
-        /// var y = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 2);
-        /// var z = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 2) }, 1);
+        /// var x = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 5), new KeyValuePair&lt;string, int>("b", 6) }, 2);
+        /// var y = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 2);
+        /// var z = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 2) }, 1);
         /// x.GroupWith(y, z).Collect();
         /// </summary>
         /// <typeparam name="K"></typeparam>
@@ -597,10 +604,10 @@ namespace Microsoft.Spark.CSharp.Core
         }
 
         /// <summary>
-        /// var x = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 5), new KeyValuePair<string, int>("b", 6) }, 2);
-        /// var y = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 1), new KeyValuePair<string, int>("b", 4) }, 2);
-        /// var z = sc.Parallelize(new[] { new KeyValuePair<string, int>("a", 2) }, 1);
-        /// var w = sc.Parallelize(new[] { new KeyValuePair<string, int>("b", 42) }, 1);
+        /// var x = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 5), new KeyValuePair&lt;string, int>("b", 6) }, 2);
+        /// var y = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 1), new KeyValuePair&lt;string, int>("b", 4) }, 2);
+        /// var z = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("a", 2) }, 1);
+        /// var w = sc.Parallelize(new[] { new KeyValuePair&lt;string, int>("b", 42) }, 1);
         /// var m = x.GroupWith(y, z, w).MapValues(l => string.Join(" ", l.Item1) + " : " + string.Join(" ", l.Item2) + " : " + string.Join(" ", l.Item3) + " : " + string.Join(" ", l.Item4)).Collect();
         /// </summary>
         /// <typeparam name="K"></typeparam>
@@ -632,31 +639,31 @@ namespace Microsoft.Spark.CSharp.Core
                 numPartitions);
         }
 
-        /// <summary>
-        /// TO DO: C# version of RDDSampler.py
-        /// Return a subset of this RDD sampled by key (via stratified sampling).
-        /// Create a sample of this RDD using variable sampling rates for
-        /// different keys as specified by fractions, a key to sampling rate map.
-        /// 
-        /// var fractions = new Dictionary<string, double> { { "a", 0.2 }, { "b", 0.1 } };
-        /// var rdd = sc.Parallelize(fractions.Keys.ToArray(), 2).Cartesian(sc.Parallelize(Enumerable.Range(0, 1000), 2));
-        /// var sample = rdd.Map(t => new KeyValuePair<string, int>(t.Item1, t.Item2)).SampleByKey(false, fractions, 2).GroupByKey().Collect();
-        /// 
-        /// 100 < sample["a"].Length < 300 and 50 < sample["b"].Length < 150
-        /// true
-        /// max(sample["a"]) <= 999 and min(sample["a"]) >= 0
-        /// true
-        /// max(sample["b"]) <= 999 and min(sample["b"]) >= 0
-        /// true
-        /// 
-        /// </summary>
-        /// <typeparam name="K"></typeparam>
-        /// <typeparam name="V"></typeparam>
-        /// <param name="self"></param>
-        /// <param name="withReplacement"></param>
-        /// <param name="fractions"></param>
-        /// <param name="seed"></param>
-        /// <returns></returns>
+        // /// <summary>
+        // /// TO DO: C# version of RDDSampler.py
+        // /// Return a subset of this RDD sampled by key (via stratified sampling).
+        // /// Create a sample of this RDD using variable sampling rates for
+        // /// different keys as specified by fractions, a key to sampling rate map.
+        // /// 
+        // /// var fractions = new Dictionary&lt;string, double> { { "a", 0.2 }, { "b", 0.1 } };
+        // /// var rdd = sc.Parallelize(fractions.Keys.ToArray(), 2).Cartesian(sc.Parallelize(Enumerable.Range(0, 1000), 2));
+        // /// var sample = rdd.Map(t => new KeyValuePair&lt;string, int>(t.Item1, t.Item2)).SampleByKey(false, fractions, 2).GroupByKey().Collect();
+        // /// 
+        // /// 100 &lt; sample["a"].Length &lt; 300 and 50 &lt; sample["b"].Length &lt; 150
+        // /// true
+        // /// max(sample["a"]) &lt;= 999 and min(sample["a"]) >= 0
+        // /// true
+        // /// max(sample["b"]) &lt;= 999 and min(sample["b"]) >= 0
+        // /// true
+        // /// 
+        // /// </summary>
+        // /// <typeparam name="K"></typeparam>
+        // /// <typeparam name="V"></typeparam>
+        // /// <param name="self"></param>
+        // /// <param name="withReplacement"></param>
+        // /// <param name="fractions"></param>
+        // /// <param name="seed"></param>
+        // /// <returns></returns>
         //public static RDD<KeyValuePair<string, V>> SampleByKey<V>(
         //    this RDD<KeyValuePair<string, V>> self,
         //    bool withReplacement,
@@ -672,8 +679,8 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Return each (key, value) pair in C{self} that has no pair with matching key in C{other}.
         /// 
-        /// var x = sc.Parallelize(new[] { new KeyValuePair<string, int?>("a", 1), new KeyValuePair<string, int?>("b", 4), new KeyValuePair<string, int?>("b", 5), new KeyValuePair<string, int?>("a", 2) }, 2);
-        /// var y = sc.Parallelize(new[] { new KeyValuePair<string, int?>("a", 3), new KeyValuePair<string, int?>("c", null) }, 2);
+        /// var x = sc.Parallelize(new[] { new KeyValuePair&lt;string, int?>("a", 1), new KeyValuePair&lt;string, int?>("b", 4), new KeyValuePair&lt;string, int?>("b", 5), new KeyValuePair&lt;string, int?>("a", 2) }, 2);
+        /// var y = sc.Parallelize(new[] { new KeyValuePair&lt;string, int?>("a", 3), new KeyValuePair&lt;string, int?>("c", null) }, 2);
         /// x.SubtractByKey(y).Collect();
         /// 
         /// [('b', 4), ('b', 5)]
@@ -697,7 +704,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// searching the partition that the key maps to.
         /// 
         /// >>> l = range(1000)
-        /// >>> rdd = sc.Parallelize(Enumerable.Range(0, 1000).Zip(Enumerable.Range(0, 1000), (x, y) => new KeyValuePair<int, int>(x, y)), 10)
+        /// >>> rdd = sc.Parallelize(Enumerable.Range(0, 1000).Zip(Enumerable.Range(0, 1000), (x, y) => new KeyValuePair&lt;int, int>(x, y)), 10)
         /// >>> rdd.lookup(42)
         /// [42]
         /// 

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
@@ -1074,6 +1074,9 @@ namespace Microsoft.Spark.CSharp.Core
         }
     }
 
+    /// <summary>
+    /// Some useful utility functions for <c>RDD{string}</c>
+    /// </summary>
     public static class StringRDDFunctions
     {
         /// <summary>
@@ -1090,6 +1093,9 @@ namespace Microsoft.Spark.CSharp.Core
         }
     }
 
+    /// <summary>
+    /// Some useful utility functions for RDD's containing IComparable values.
+    /// </summary>
     public static class ComparableRDDFunctions
     {
         /// <summary>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// True
         /// 
         /// </summary>
-        /// <param name="storageLevel"></param>
+        /// <param name="storageLevelType"></param>
         /// <returns></returns>
         public RDD<T> Persist(StorageLevelType storageLevelType)
         {
@@ -159,7 +159,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Return a new RDD by applying a function to each element of this RDD.
         /// 
-        /// sc.Parallelize(new string[]{"b", "a", "c"}, 1).Map(x => new KeyValuePair<string, int>(x, 1)).Collect()
+        /// sc.Parallelize(new string[]{"b", "a", "c"}, 1).Map(x => new KeyValuePair&lt;string, int>(x, 1)).Collect()
         /// [('a', 1), ('b', 1), ('c', 1)]
         /// 
         /// </summary>
@@ -209,7 +209,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// Return a new RDD by applying a function to each partition of this RDD,
         /// while tracking the index of the original partition.
         /// 
-        /// sc.Parallelize(new int[]{1, 2, 3, 4}, 4).MapPartitionsWithIndex<double>((pid, iter) => (double)pid).Sum()
+        /// sc.Parallelize(new int[]{1, 2, 3, 4}, 4).MapPartitionsWithIndex&lt;double>((pid, iter) => (double)pid).Sum()
         /// 6
         /// </summary>
         /// <typeparam name="U"></typeparam>
@@ -262,7 +262,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// Return a sampled subset of this RDD.
         ///
         /// var rdd = sc.Parallelize(Enumerable.Range(0, 100), 4)
-        /// 6 <= rdd.Sample(False, 0.1, 81).count() <= 14
+        /// 6 &lt;= rdd.Sample(False, 0.1, 81).count() &lt;= 14
         /// true
         /// 
         /// </summary>
@@ -282,8 +282,8 @@ namespace Microsoft.Spark.CSharp.Core
         ///
         /// var rdd = sc.Parallelize(Enumerable.Range(0, 500), 1)
         /// var rdds = rdd.RandomSplit(new double[] {2, 3}, 17)
-        /// 150 < rdds[0].Count() < 250
-        /// 250 < rdds[1].Count() < 350
+        /// 150 &lt; rdds[0].Count() &lt; 250
+        /// 250 &lt; rdds[1].Count() &lt; 350
         /// 
         /// </summary>
         /// <param name="weights">weights for splits, will be normalized if they don't sum to 1</param>
@@ -362,9 +362,9 @@ namespace Microsoft.Spark.CSharp.Core
         /// q > p such that
         ///   - when sampling with replacement, we're drawing each data point
         ///     with prob_i ~ Pois(q), where we want to guarantee
-        ///     Pr[s < num] < 0.0001 for s = sum(prob_i for i from 0 to
+        ///     Pr[s &lt; num] &lt; 0.0001 for s = sum(prob_i for i from 0 to
         ///     total), i.e. the failure rate of not having a sufficiently large
-        ///     sample < 0.0001. Setting q = p + 5 * sqrt(p/total) is sufficient
+        ///     sample &lt; 0.0001. Setting q = p + 5 * sqrt(p/total) is sufficient
         ///     to guarantee 0.9999 success rate for num > 12, but we need a
         ///     slightly larger q (9 empirically determined).
         ///   - when sampling without replacement, we're drawing each data point
@@ -431,21 +431,21 @@ namespace Microsoft.Spark.CSharp.Core
                 .Keys();
         }
 
-        /// <summary>
-        /// Sorts this RDD by the given keyfunc
-        /// 
-        /// >>> tmp = [('a', 1), ('b', 2), ('1', 3), ('d', 4), ('2', 5)]
-        /// >>> sc.Parallelize(tmp).sortBy(lambda x: x[0]).collect()
-        /// [('1', 3), ('2', 5), ('a', 1), ('b', 2), ('d', 4)]
-        /// >>> sc.Parallelize(tmp).sortBy(lambda x: x[1]).collect()
-        /// [('a', 1), ('b', 2), ('1', 3), ('d', 4), ('2', 5)]
-        /// 
-        /// </summary>
-        /// <typeparam name="K"></typeparam>
-        /// <param name="keyfunc"></param>
-        /// <param name="ascending"></param>
-        /// <param name="numPartitions"></param>
-        /// <returns></returns>
+        // /// <summary>
+        // /// Sorts this RDD by the given keyfunc
+        // /// 
+        // /// >>> tmp = [('a', 1), ('b', 2), ('1', 3), ('d', 4), ('2', 5)]
+        // /// >>> sc.Parallelize(tmp).sortBy(lambda x: x[0]).collect()
+        // /// [('1', 3), ('2', 5), ('a', 1), ('b', 2), ('d', 4)]
+        // /// >>> sc.Parallelize(tmp).sortBy(lambda x: x[1]).collect()
+        // /// [('a', 1), ('b', 2), ('1', 3), ('d', 4), ('2', 5)]
+        // /// 
+        // /// </summary>
+        // /// <typeparam name="K"></typeparam>
+        // /// <param name="keyfunc"></param>
+        // /// <param name="ascending"></param>
+        // /// <param name="numPartitions"></param>
+        // /// <returns></returns>
         //public RDD<T> SortBy<K>(Func<T, K> keyfunc, bool ascending = true, int? numPartitions = null)
         //{
         //    return KeyBy<K>(keyfunc).SortByKey<K, T>(ascending, numPartitions).Map<T>(kv => kv.Value);
@@ -868,6 +868,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// 
         /// </summary>
         /// <param name="other"></param>
+        /// <param name="numPartitions"></param>
         /// <returns></returns>
         public RDD<T> Subtract(RDD<T> other, int numPartitions = 0)
         {
@@ -926,6 +927,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// 
         /// </summary>
         /// <param name="numPartitions"></param>
+        /// <param name="shuffle"></param>
         /// <returns></returns>
         public RDD<T> Coalesce(int numPartitions, bool shuffle = false)
         {
@@ -1077,8 +1079,6 @@ namespace Microsoft.Spark.CSharp.Core
         /// <summary>
         /// Save this RDD as a text file, using string representations of elements.
         /// </summary>
-        /// <typeparam name="K"></typeparam>
-        /// <typeparam name="V"></typeparam>
         /// <param name="self"></param>
         /// <param name="path">path to text file</param>
         /// <param name="compressionCodecClass">(None by default) string i.e. "org.apache.hadoop.io.compress.GzipCodec"</param>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/SparkContext.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/SparkContext.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// Hadoop-supported file system URI. Each file is read as a single record and returned in a
         /// key-value pair, where the key is the path of each file, the value is the content of each file.
         ///
-        /// <p> For example, if you have the following files:
+        /// &lt;p> For example, if you have the following files:
         /// {{{
         ///   hdfs://a-hdfs-path/part-00000
         ///   hdfs://a-hdfs-path/part-00001
@@ -160,10 +160,10 @@ namespace Microsoft.Spark.CSharp.Core
         ///
         /// Do
         /// {{{
-        ///   JavaPairRDD<String, String> rdd = sparkContext.wholeTextFiles("hdfs://a-hdfs-path")
+        ///   JavaPairRDD&lt;String, String> rdd = sparkContext.wholeTextFiles("hdfs://a-hdfs-path")
         /// }}}
         ///
-        /// <p> then `rdd` contains
+        /// &lt;p> then `rdd` contains
         /// {{{
         ///   (a-hdfs-path/part-00000, its content)
         ///   (a-hdfs-path/part-00001, its content)
@@ -198,7 +198,7 @@ namespace Microsoft.Spark.CSharp.Core
         /// }}}
         ///
         /// Do
-        /// `JavaPairRDD<String, byte[]> rdd = sparkContext.dataStreamFiles("hdfs://a-hdfs-path")`,
+        /// `JavaPairRDD&lt;String, byte[]> rdd = sparkContext.dataStreamFiles("hdfs://a-hdfs-path")`,
         ///
         /// then `rdd` contains
         /// {{{
@@ -259,7 +259,6 @@ namespace Microsoft.Spark.CSharp.Core
         /// <param name="keyConverterClass">(None by default)</param>
         /// <param name="valueConverterClass">(None by default)</param>
         /// <param name="conf"> Hadoop configuration, passed in as a dict (None by default)</param>
-        /// <param name="batchSize"></param>
         /// <returns></returns>
         public RDD<byte[]> NewAPIHadoopFile(string filePath, string inputFormatClass, string keyClass, string valueClass, string keyConverterClass = null, string valueConverterClass = null, IEnumerable<KeyValuePair<string, string>> conf = null)
         {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
@@ -221,22 +221,22 @@ namespace Microsoft.Spark.CSharp.Sql
         }
 
         /// <summary>
-        /// Join with another DataFrame
+        /// Join with another DataFrame - Cartesian join
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
         /// <returns>Joined DataFrame</returns>
-        public DataFrame Join(DataFrame otherDataFrame) //cartesian join
+        public DataFrame Join(DataFrame otherDataFrame)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Join with another DataFrame
+        /// Join with another DataFrame - Inner equi-join using given column name
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
         /// <param name="joinColumnName">Column to join with.</param>
         /// <returns>Joined DataFrame</returns>
-        public DataFrame Join(DataFrame otherDataFrame, string joinColumnName) //inner equi join using given column name //need aliasing for self join
+        public DataFrame Join(DataFrame otherDataFrame, string joinColumnName) // TODO: need aliasing for self join
         {
             return new DataFrame(
                 dataFrameProxy.Join(otherDataFrame.dataFrameProxy, joinColumnName),
@@ -244,12 +244,12 @@ namespace Microsoft.Spark.CSharp.Sql
         }
 
         /// <summary>
-        /// Join with another DataFrame
+        /// Join with another DataFrame - Inner equi-join using given column name 
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
         /// <param name="joinColumnNames">Columns to join with.</param>
         /// <returns>Joined DataFrame</returns>
-        public DataFrame Join(DataFrame otherDataFrame, string[] joinColumnNames) //inner equi join using given column name //need aliasing for self join
+        public DataFrame Join(DataFrame otherDataFrame, string[] joinColumnNames) // TODO: need aliasing for self join
         {
             return new DataFrame(
                 dataFrameProxy.Join(otherDataFrame.dataFrameProxy, joinColumnNames),
@@ -257,11 +257,11 @@ namespace Microsoft.Spark.CSharp.Sql
         }
 
         /// <summary>
-        /// Join with another DataFrame
+        /// Join with another DataFrame, using the specified JoinType
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
         /// <param name="joinExpression">Column to join with.</param>
-        /// <param name="joinType">Type og join to perform.</param>
+        /// <param name="joinType">Type of join to perform (default null value means <c>JoinType.Inner</c>)</param>
         /// <returns>Joined DataFrame</returns>
         public DataFrame Join(DataFrame otherDataFrame, Column joinExpression, JoinType joinType = null) 
         {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Spark.CSharp.Sql
         ///   df.SelectExpr("colA", "colB as newName", "abs(colC)")
         ///   
         /// </summary>
-        /// <param name="columns"></param>
+        /// <param name="columnExpressions"></param>
         /// <returns></returns>
         public DataFrame SelectExpr(params string[] columnExpressions)
         {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
@@ -155,16 +155,16 @@ namespace Microsoft.Spark.CSharp.Sql
             return new DataFrame(dataFrameProxy.SelectExpr(columnExpressions), sparkContext);
         }
 
-        /// <summary>
-        /// TO DO:  to be decided whether to expose this API
-        /// 
-        ///     1. has alternative - sql("<SQL scripts>")
-        ///     2. perf impact comapred to sql() - 1 more java call per each Column in select list
-        ///     
-        /// Select a list of columns
-        /// </summary>
-        /// <param name="columnNames"></param>
-        /// <returns></returns>
+        // /// <summary>
+        // /// TO DO:  to be decided whether to expose this API
+        // /// 
+        // ///     1. has alternative - sql("<SQL scripts>")
+        // ///     2. perf impact comapred to sql() - 1 more java call per each Column in select list
+        // ///     
+        // /// Select a list of columns
+        // /// </summary>
+        // /// <param name="columns"></param>
+        // /// <returns></returns>
         //public DataFrame Select(params Column[] columns)
         //{
         //    List<IColumnProxy> columnReferenceList = columns.Select(column => column.ColumnProxy).ToList();

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Spark.CSharp.Core;
 using Microsoft.Spark.CSharp.Proxy;
-using Microsoft.Spark.CSharp.Interop;
 
 namespace Microsoft.Spark.CSharp.Sql
 {
@@ -149,7 +148,7 @@ namespace Microsoft.Spark.CSharp.Sql
         ///   df.SelectExpr("colA", "colB as newName", "abs(colC)")
         ///   
         /// </summary>
-        /// <param name="columnNames"></param>
+        /// <param name="columns"></param>
         /// <returns></returns>
         public DataFrame SelectExpr(params string[] columnExpressions)
         {
@@ -235,6 +234,7 @@ namespace Microsoft.Spark.CSharp.Sql
         /// Join with another DataFrame
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
+        /// <param name="joinColumnName">Column to join with.</param>
         /// <returns>Joined DataFrame</returns>
         public DataFrame Join(DataFrame otherDataFrame, string joinColumnName) //inner equi join using given column name //need aliasing for self join
         {
@@ -247,6 +247,7 @@ namespace Microsoft.Spark.CSharp.Sql
         /// Join with another DataFrame
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
+        /// <param name="joinColumnNames">Columns to join with.</param>
         /// <returns>Joined DataFrame</returns>
         public DataFrame Join(DataFrame otherDataFrame, string[] joinColumnNames) //inner equi join using given column name //need aliasing for self join
         {
@@ -259,6 +260,8 @@ namespace Microsoft.Spark.CSharp.Sql
         /// Join with another DataFrame
         /// </summary>
         /// <param name="otherDataFrame">DataFrame to join with</param>
+        /// <param name="joinExpression">Column to join with.</param>
+        /// <param name="joinType">Type og join to perform.</param>
         /// <returns>Joined DataFrame</returns>
         public DataFrame Join(DataFrame otherDataFrame, Column joinExpression, JoinType joinType = null) 
         {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Functions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Functions.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Spark.CSharp.Sql
 
             if (types.Any(t => !returnTypes.ContainsKey(t)))
             {
-                throw new ArgumentException(string.Format("{0} not supported. Supported types: {1}", type.Name), string.Join(",", returnTypes.Keys));
+                throw new ArgumentException(string.Format("{0} not supported. Supported types: {1}", type.Name, string.Join(",", returnTypes.Keys)));
             }
 
             return string.Format(returnTypeFormat, types.Select(t => returnTypes[t]).ToArray());

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/StreamingContext.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/StreamingContext.cs
@@ -10,17 +10,19 @@ using Microsoft.Spark.CSharp.Core;
 
 namespace Microsoft.Spark.CSharp.Streaming
 {
-    /**
-     * Main entry point for Spark Streaming functionality. It provides methods used to create
-     * [[org.apache.spark.streaming.dstream.DStream]]s from various input sources. It can be either
-     * created by providing a Spark master URL and an appName, or from a org.apache.spark.SparkConf
-     * configuration (see core Spark documentation), or from an existing org.apache.spark.SparkContext.
-     * The associated SparkContext can be accessed using `context.sparkContext`. After
-     * creating and transforming DStreams, the streaming computation can be started and stopped
-     * using `context.start()` and `context.stop()`, respectively.
-     * `context.awaitTermination()` allows the current thread to wait for the termination
-     * of the context by `stop()` or by an exception.
-     */
+    /// <summary>
+    /// Main entry point for Spark Streaming functionality. 
+    /// It provides methods used to create <see cref="DStream{T}"/>s from various input sources. 
+    /// It can be either created by providing a Spark master URL and an appName, 
+    /// or from a org.apache.spark.SparkConf configuration (see core Spark documentation), 
+    /// or from an existing org.apache.spark.SparkContext.
+    /// The associated SparkContext can be accessed using `context.sparkContext`. 
+    /// After creating and transforming DStreams, the streaming computation can be started 
+    /// and stopped using `context.start()` and `context.stop()`, respectively.
+    /// Methods `context.awaitTermination()` allows the current thread to wait 
+    /// for the termination of the context by `stop()` or by an exception.
+    /// </summary>
+    /// <seealso cref="DStream{T}"/>
     public class StreamingContext
     {
         public StreamingContext(SparkContext sparkContext, long durationMS)
@@ -28,25 +30,25 @@ namespace Microsoft.Spark.CSharp.Streaming
             throw new NotImplementedException();
         }
 
-        /**
-         * Set each DStreams in this context to remember RDDs it generated in the last given duration.
-         * DStreams remember RDDs only for a limited duration of time and releases them for garbage
-         * collection. This method allows the developer to specify how long to remember the RDDs (
-         * if the developer wishes to query old data outside the DStream computation).
-         * @param duration Minimum duration that each DStream should remember its RDDs
-         */
+        /// <summary>
+        /// Set each DStreams in this context to remember RDDs it generated in the last given duration.
+        /// DStreams remember RDDs only for a limited duration of time and releases them for garbage
+        /// collection. This method allows the developer to specify how long to remember the RDDs (
+        /// if the developer wishes to query old data outside the DStream computation).
+        /// </summary>
+        /// <param name="durationMS">Minimum duration that each DStream should remember its RDDs</param>
         public void Remember(long durationMS)
         {
             throw new NotImplementedException();
         }
 
-        /**
-         * Set the context to periodically checkpoint the DStream operations for driver
-         * fault-tolerance.
-         * @param directory HDFS-compatible directory where the checkpoint data will be reliably stored.
-         *                  Note that this must be a fault-tolerant file system like HDFS for
-         */
-        public void checkpoint(string directory)
+        /// <summary>
+        /// Set the context to periodically checkpoint the DStream operations for driver
+        /// fault-tolerance.
+        /// </summary>
+        /// <param name="directory">HDFS-compatible directory where the checkpoint data will be reliably stored.
+        /// Note that this must be a fault-tolerant file system like HDFS.</param>
+        public void Checkpoint(string directory)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Fix some minor issues in code-docs and messages.

- Fix various minor issues with XML code-docs.

- Mostly required replacing < with &lt; for valid XML.

- Fix minor typo in comment.

- Fix wrong parameters being passed into string.Format