### PR TITLE
Minor code tweaks 1105

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
@@ -558,11 +558,11 @@ namespace Microsoft.Spark.CSharp.Core
 
             using (BinaryReader br = new BinaryReader(ns))
             {
-                byte[] buffer = null;
+                byte[] buffer;
                 do
                 {
                     buffer = br.ReadBytes(4);
-                    if (buffer != null && buffer.Length > 0)
+                    if (buffer.Length > 0)
                     {
                         Array.Reverse(buffer);
                         int len = BitConverter.ToInt32(buffer, 0);
@@ -588,7 +588,7 @@ namespace Microsoft.Spark.CSharp.Core
                             items.Add(ci.Invoke(new object[] { formatter.Deserialize(ms), formatter.Deserialize(ms2) }));
                         }
                     }
-                } while (buffer != null && buffer.Length > 0);
+                } while (buffer.Length > 0);
             }
 
             return items.Cast<T>().ToArray();

--- a/csharp/Samples/Microsoft.Spark.CSharp/MiscSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/MiscSamples.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Spark.CSharp.Samples
         /// Sample to compute th evalue of Pi
         /// </summary>
         [Sample]
-        private static void PiSample()
+        internal static void PiSample()
         {
             var slices = 2;
             var n = (int) Math.Min(100000L*slices, int.MaxValue);
@@ -48,7 +48,6 @@ namespace Microsoft.Spark.CSharp.Samples
             /********************************************************************/
         }
 
-        
         [Serializable]
         private class PiHelper
         {
@@ -61,7 +60,5 @@ namespace Microsoft.Spark.CSharp.Samples
                 return (x * x + y * y) < 1 ? 1 : 0;    
             }
         }
-        
-
     }
 }


### PR DESCRIPTION
Minor code tweaks

- The `buffer` variable in `RDD.Collect` can never be null, so that check can be removed from the loop.

- Make `PiSample` more discoverable, by making it have same `internal` visibility as other Samples project example code.
