### PR TITLE
Missing methods in MockDataFrameProxy

### DIFF
--- a/csharp/AdapterTest/Mocks/MockDataFrameProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockDataFrameProxy.cs
@@ -216,5 +216,15 @@ namespace AdapterTest.Mocks
         {
             throw new NotImplementedException();
         }
+
+        public IDataFrameProxy Drop(string columnName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDataFrameProxy DropNa(string how, int? thresh, string[] subset)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Add the missing methods in MockDataFrameProxy

- Fixes build break from PR #22
https://github.com/Microsoft/SparkCLR/pull/22