### PR TITLE
Add collect() API for DataFrame

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Adapter.csproj
@@ -36,6 +36,15 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Razorvine.Pyrolite">
+      <HintPath>..\..\packages\Razorvine.Pyrolite.4.10.0.0\lib\net40\Razorvine.Pyrolite.dll</HintPath>
+    </Reference>
+    <Reference Include="Razorvine.Serpent">
+      <HintPath>..\..\packages\Razorvine.Serpent.1.12.0.0\lib\net40\Razorvine.Serpent.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -92,6 +101,7 @@
     <Compile Include="Services\LoggerServiceFactory.cs" />
     <Compile Include="Sql\Column.cs" />
     <Compile Include="Sql\DataFrame.cs" />
+    <Compile Include="Sql\Row.cs" />
     <Compile Include="Sql\Functions.cs" />
     <Compile Include="Sql\SqlContext.cs" />
     <Compile Include="Sql\Struct.cs" />
@@ -102,6 +112,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/IDataFrameProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/IDataFrameProxy.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Spark.CSharp.Proxy
     {
         void RegisterTempTable(string tableName);
         long Count();
+        int CollectAndServe();
         string GetQueryExecution();
         string GetExecutedPlan();
         string GetShowString(int numberOfRows, bool truncate);

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/IStructProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/IStructProxy.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Spark.CSharp.Proxy
     interface IStructTypeProxy
     {
         List<IStructFieldProxy> GetStructTypeFields();
+        string ToJson();
     }
 
     interface IStructDataTypeProxy

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/DataFrameIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/DataFrameIpcProxy.cs
@@ -36,6 +36,22 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                         jvmDataFrameReference, "count").ToString());
         }
 
+        /// <summary>
+        /// Call CollectAndServe() in Java side, it will collect an RDD as an iterator, then serve it via socket
+        /// </summary>
+        /// <returns>the port number of a local socket which serves the data collected</returns>
+        public int CollectAndServe()
+        {
+            var javaRDDReference = new JvmObjectReference(
+                (string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmDataFrameReference, "javaToPython"));
+            var rddReference = new JvmObjectReference(
+                (string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(javaRDDReference, "rdd"));
+            return int.Parse(SparkCLRIpcProxy.JvmBridge.CallStaticJavaMethod(
+                "org.apache.spark.api.python.PythonRDD",
+                "collectAndServe",
+                new object[] { rddReference }).ToString());
+        }
+
         public string GetQueryExecution()
         {
             var queryExecutionReference = GetQueryExecutionReference();

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StructIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StructIpcProxy.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
             var fieldsReferenceList = SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmStructTypeReference, "fields");
             return (fieldsReferenceList as List<JvmObjectReference>).Select(s => new StructFieldIpcProxy(s)).Cast<IStructFieldProxy>().ToList();
         }
+
+        public string ToJson()
+        {
+            return SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmStructTypeReference, "json").ToString();
+        }
     }
 
     internal class StructDataTypeIpcProxy : IStructDataTypeProxy

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
@@ -4,8 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+using System.Net.Sockets;
+
+using Razorvine.Pickle;
+
 using Microsoft.Spark.CSharp.Core;
 using Microsoft.Spark.CSharp.Proxy;
+using Microsoft.Spark.CSharp.Interop;
 
 namespace Microsoft.Spark.CSharp.Sql
 {
@@ -19,6 +27,7 @@ namespace Microsoft.Spark.CSharp.Sql
         private IDataFrameProxy dataFrameProxy;
         private readonly SparkContext sparkContext;
         private StructType schema;
+        private RowSchema rowSchema;
         
         internal SparkContext SparkContext
         {
@@ -90,9 +99,65 @@ namespace Microsoft.Spark.CSharp.Sql
             Console.WriteLine(string.Join(", ", nameTypeList));
         }
 
+        /// <summary>
+        /// Returns all of Rows in this DataFrame
+        /// </summary>
         public IEnumerable<Row> Collect()
         {
-            throw new NotImplementedException();
+            int port = dataFrameProxy.CollectAndServe();
+            RowSchema rs = GetRowSchema();
+            List<Row> items = Collect(port, rs);
+            return items.AsEnumerable<Row>();
+        }
+
+        private RowSchema GetRowSchema()
+        {
+            if (rowSchema == null)
+            {
+                string json = Schema.ToJson();
+                rowSchema = RowSchema.ParseRowSchemaFromJson(json);
+            }
+            return rowSchema;
+        }
+
+        private List<Row> Collect(int port, RowSchema dataType)
+        {
+            List<Row> items = new List<Row>();
+            IFormatter formatter = new BinaryFormatter();
+            Unpickler unpickler = new Unpickler();
+            Socket sock = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            sock.Connect("127.0.0.1", port);
+            NetworkStream ns = new NetworkStream(sock);
+
+            using (BinaryReader br = new BinaryReader(ns))
+            {
+                byte[] buffer = null;
+                do
+                {
+                    buffer = br.ReadBytes(4);
+                    if (buffer != null && buffer.Length > 0)
+                    {
+                        //In JVM, Multibyte data items are always stored in big-endian order, where the high bytes come first
+                        //http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html
+                        //So we should handle revert buffer if our system is little-endian
+                        //https://msdn.microsoft.com/en-us/library/system.bitconverter(v=vs.110).aspx
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            Array.Reverse(buffer);
+                        }
+
+                        int len = BitConverter.ToInt32(buffer, 0);
+                        byte[] data = br.ReadBytes(len);
+                        foreach (var item in (unpickler.loads(data) as object[]))
+                        {
+                            RowImpl row = new RowImpl(item, dataType);
+                            items.Add(row);
+                        }
+                    }
+                } while (buffer != null && buffer.Length > 0);
+            }
+
+            return items;
         }
 
         /// <summary>
@@ -337,12 +402,6 @@ namespace Microsoft.Spark.CSharp.Sql
             return
                 new DataFrame(dataFrameProxy.DropNa(how, thresh, subset), sparkContext);
         }
-    }
-
-    //TODO - complete impl
-    public class Row
-    {
-        
     }
 
     public class JoinType

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Row.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Row.cs
@@ -1,0 +1,308 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using Microsoft.Spark.CSharp.Services;
+
+namespace Microsoft.Spark.CSharp.Sql
+{
+    /// <summary>
+    ///  Represents one row of output from a relational operator.
+    /// </summary>
+    public abstract class Row
+    {
+        private ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(Row));
+
+        /// <summary>
+        /// Number of elements in the Row.
+        /// </summary>
+        /// <returns>elements count in this row</returns>
+        public abstract int Size();
+
+        /// <summary>
+        /// Schema for the row.
+        /// </summary>
+        public abstract RowSchema GetSchema();
+
+        /// <summary>
+        /// Returns the value at position i.
+        /// </summary>
+        public abstract object Get(int i);
+
+        /// <summary>
+        /// Returns the value of a given columnName.
+        /// </summary>
+        public abstract object Get(string columnName);
+
+        /// <summary>
+        /// Returns the value at position i, the return value will be cast to type T.
+        /// </summary>
+        public T GetAs<T>(int i)
+        {
+            object o = Get(i);
+            try
+            {
+                T result = (T)o;
+                return result;
+            }
+            catch
+            {
+                logger.LogError(string.Format("type convertion failed from {0} to {1}", o.GetType(), typeof(T)));
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Returns the value of a given columnName, the return value will be cast to type T.
+        /// </summary>
+        public T GetAs<T>(string columnName)
+        {
+            object o = Get(columnName);
+            try
+            {
+                T result = (T)o;
+                return result;
+            }
+            catch
+            {
+                logger.LogError(string.Format("type convertion failed from {0} to {1}", o.GetType(), typeof(T)));
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Schema of Row
+    /// </summary>
+    public class RowSchema
+    {
+        public string type;
+        public List<ColumnSchema> columns;
+
+        private Dictionary<string, int> columnName2Index = new Dictionary<string, int>();
+
+        public RowSchema(string type)
+        {
+            this.type = type;
+            this.columns = new List<ColumnSchema>();
+        }
+
+        public RowSchema(string type, List<ColumnSchema> cols)
+        {
+            int index = 0;
+            foreach (var col in cols)
+            {
+                string columnName = col.name;
+
+                if (string.IsNullOrEmpty(columnName))
+                {
+                    throw new Exception(string.Format("Null column name at pos: {0}", index));
+                }
+
+                if (columnName2Index.ContainsKey(columnName))
+                {
+                    throw new Exception(string.Format("duplicate column name ({0}) in pos ({1}) and ({2})",
+                        columnName, columnName2Index[columnName], index));
+                }
+                columnName2Index[columnName] = index;
+                index++;
+            }
+
+            this.type = type;
+            this.columns = cols;
+        }
+
+        internal int GetIndexByColumnName(string ColumnName)
+        {
+            if (!columnName2Index.ContainsKey(ColumnName))
+            {
+                throw new Exception(string.Format("unknown ColumnName: {0}", ColumnName));
+            }
+
+            return columnName2Index[ColumnName];
+        }
+
+        public override string ToString()
+        {
+            string result;
+
+            if (columns.Any())
+            {
+                List<string> cols = new List<string>();
+                foreach (var col in columns)
+                {
+                    cols.Add(col.ToString());
+                }
+
+                result = "{" +
+                    string.Format("type: {0}, columns: [{1}]", type, string.Join(", ", cols.ToArray())) +
+                    "}";
+            }
+            else
+            {
+                result = type;
+            }
+
+            return result;
+        }
+
+        internal static RowSchema ParseRowSchemaFromJson(string json)
+        {
+            JObject joType = JObject.Parse(json);
+            string type = joType["type"].ToString();
+
+            List<ColumnSchema> columns = new List<ColumnSchema>();
+            List<JToken> jtFields = joType["fields"].Children().ToList();
+            foreach (JToken jtField in jtFields)
+            {
+                ColumnSchema col = ColumnSchema.ParseColumnSchemaFromJson(jtField.ToString());
+                columns.Add(col);
+            }
+
+            return new RowSchema(type, columns);
+        }
+
+    }
+
+    /// <summary>
+    /// Schema for column
+    /// </summary>
+    public class ColumnSchema
+    {
+        public string name;
+        public RowSchema type;
+        public bool nullable;
+
+        public override string ToString()
+        {
+            string str = string.Format("name: {0}, type: {1}, nullable: {2}", name, type, nullable);
+            return "{" + str + "}";
+        }
+
+        internal static ColumnSchema ParseColumnSchemaFromJson(string json)
+        {
+            ColumnSchema col = new ColumnSchema();
+            JObject joField = JObject.Parse(json);
+            col.name = joField["name"].ToString();
+            col.nullable = (bool)(joField["nullable"]);
+
+            JToken jtType = joField["type"];
+            if (jtType.Type == JTokenType.String)
+            {
+                col.type = new RowSchema(joField["type"].ToString());
+            }
+            else
+            {
+                col.type = RowSchema.ParseRowSchemaFromJson(joField["type"].ToString());
+            }
+
+            return col;
+        }
+    }
+
+    internal class RowImpl : Row
+    {
+        private RowSchema schema;
+        private object[] values;
+
+        private int columnCount;
+
+        internal RowImpl(object data, RowSchema schema)
+        {
+            if (data is object[])
+            {
+                values = data as object[];
+            }
+            else if (data is List<object>)
+            {
+                values = (data as List<object>).ToArray();
+            }
+            else
+            {
+                throw new Exception(string.Format("unexpeted type {0}", data.GetType()));
+            }
+
+            this.schema = schema;
+
+            columnCount = values.Count();
+            int schemaColumnCount = this.schema.columns.Count();
+            if (columnCount != schemaColumnCount)
+            {
+                throw new Exception(string.Format("column count inferred from data ({0}) and schema ({1}) mismatch", columnCount, schemaColumnCount));
+            }
+
+            Initialize();
+        }
+
+        public override int Size()
+        {
+            return columnCount;
+        }
+
+        public override RowSchema GetSchema()
+        {
+            return schema;
+        }
+
+        public override object Get(int i)
+        {
+            if (i >= columnCount)
+            {
+                throw new Exception(string.Format("i ({0}) >= columnCount ({1})", i, columnCount));
+            }
+
+            return values[i];
+        }
+
+        public override object Get(string columnName)
+        {
+            int index = schema.GetIndexByColumnName(columnName);
+            return Get(index);
+        }
+
+        public override string ToString()
+        {
+            List<string> cols = new List<string>();
+            foreach (var item in values)
+            {
+                if (item != null)
+                {
+                    cols.Add(item.ToString());
+                }
+                else
+                {
+                    cols.Add(string.Empty);
+                }
+            }
+
+            return string.Format("[{0}]", string.Join(",", cols.ToArray()));
+        }
+
+
+        private void Initialize()
+        {
+            int index = 0;
+            foreach (var col in schema.columns)
+            {
+                if (col.type.columns.Any()) // this column itself is a sub-row
+                {
+                    object value = values[index];
+                    if (value != null)
+                    {
+                        RowImpl subRow = new RowImpl(values[index], col.type);
+                        values[index] = subRow;
+                    }
+                }
+
+                index++;
+            }
+        }
+    }
+}

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Struct.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Struct.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Spark.CSharp.Sql
             }
         }
 
+        public string ToJson()
+        {
+            return structTypeProxy.ToJson();
+        }
+
+
         internal StructType(IStructTypeProxy structTypeProxy)
         {
             this.structTypeProxy = structTypeProxy;

--- a/csharp/AdapterTest/Mocks/MockDataFrameProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockDataFrameProxy.cs
@@ -37,6 +37,12 @@ namespace AdapterTest.Mocks
             throw new NotImplementedException();
         }
 
+
+        public int CollectAndServe()
+        {
+            throw new NotImplementedException();
+        }
+
         public string GetQueryExecution()
         {
             throw new NotImplementedException();

--- a/csharp/Samples/Microsoft.Spark.CSharp/DataFrameSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/DataFrameSamples.cs
@@ -37,6 +37,60 @@ namespace Microsoft.Spark.CSharp.Samples
         }
 
         /// <summary>
+        /// Sample to get schema of DataFrame in json format
+        /// </summary>
+        [Sample]
+        internal static void DFGetSchemaToJsonSample()
+        {
+            var peopleDataFrame = GetSqlContext().JsonFile(SparkCLRSamples.Configuration.GetInputDataPath(PeopleJson));
+            string json = peopleDataFrame.Schema.ToJson();
+            Console.WriteLine("schema in json format: {0}", json);
+        }
+
+        /// <summary>
+        /// Sample to run collect for DataFrame
+        /// </summary>
+        [Sample]
+        internal static void DFCollectSample()
+        {
+            var peopleDataFrame = GetSqlContext().JsonFile(SparkCLRSamples.Configuration.GetInputDataPath(PeopleJson));
+            IEnumerable<Row> rows = peopleDataFrame.Collect();
+            Console.WriteLine("peopleDataFrame:");
+            int i = 0;
+
+            foreach (var row in rows)
+            {
+                if (i == 0)
+                {
+                    Console.WriteLine("schema: {0}", row.GetSchema());
+                }
+
+                // output the whole row as a string
+                Console.WriteLine(row);
+
+                // output each field of the row, including fields in subrow
+                string id = row.GetAs<string>("id");
+                string name = row.GetAs<string>("name");
+                int age = row.GetAs<int>("age");
+                Console.Write("id: {0}, name: {1}, age: {2}", id, name, age);
+
+                Row address = row.GetAs<Row>("address");
+                if (address != null)
+                {
+                    string city = address.GetAs<string>("city");
+                    string state = address.GetAs<string>("state");
+                    Console.WriteLine(", state: {0}, city: {1}", state, city);
+                }
+                else
+                {
+                    Console.WriteLine();
+                }
+
+                i++;
+            }
+        }
+
+        /// <summary>
         /// Sample to register a DataFrame as temptable and run queries
         /// </summary>
         [Sample]


### PR DESCRIPTION
     Work flow:
     Java Side:
     1. Call javaToPython() to convert DataFrame to javaRDD[Array[Byte]]
     2. Get RDD [Array[Byte]] from javaRDD[Array[Byte]]
     3. Call PythonRDD.collectAndServe to send the RDD via socket

     C# side:
     1. Read from socket and construct a list of Row.
     2. Convert the list to IEnumerable and return

     Code change:
     1. Add a file Row.cs, defining the class Row and RowImpl.
     2. Add RPC call to get datatype info from Java side in json format.
     Here is an example:
     {"type":"struct","fields":[{"name":"address","type":{"type":"struct","fields":[{"name":"city","type":"string","nullable":true,"metadata":{}},{"name":"state","type":"string","nullable":true,"metadata":{}}]},"nullable":true,"metadata":{}},{"name":"age","type":"long","nullable":true,"metadata":{}},{"name":"id","type":"string","nullable":true,"metadata":{}},{"name":"name","type":"string","nullable":true,"metadata":{}}]}
     3. use Json.NET library to parse this json string to get DataType info for Row.
     4. Use the DataType info to construct RowImpl instance from unpicked object