### PR TITLE
Minor improvements to handling some error conditions.

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -153,16 +153,15 @@ namespace Microsoft.Spark.CSharp.Configuration
                 : base(configuration)
             {}
 
-            internal override string GetCSharpRDDExternalProcessName()
-            {
-                return appSettings.Settings["CSharpWorkerPath"].Value;
-            }
-            
             internal override string GetCSharpWorkerPath()
             {
-                return new Uri(appSettings.Settings["CSharpWorkerPath"].Value).ToString();
+                KeyValueConfigurationElement workerPathConfig = appSettings.Settings["CSharpWorkerPath"];
+                if (workerPathConfig == null)
+                {
+                    throw new ConfigurationErrorsException("Need to set CSharpWorkerPath value in App.config");
+                }
+                return new Uri(workerPathConfig.Value).ToString();
             }
-
         }
 
         /// <summary>
@@ -177,7 +176,12 @@ namespace Microsoft.Spark.CSharp.Configuration
 
             internal override int GetPortNumber()
             {
-                var cSharpBackendPortNumber = int.Parse(appSettings.Settings["CSharpBackendPortNumber"].Value);
+                KeyValueConfigurationElement portConfig = appSettings.Settings["CSharpBackendPortNumber"];
+                if (portConfig == null)
+                {
+                    throw new ConfigurationErrorsException("Need to set CSharpBackendPortNumber value in App.config");
+                }
+                int cSharpBackendPortNumber = int.Parse(portConfig.Value);
                 logger.LogInfo(string.Format("CSharpBackend port number read from app config {0}", cSharpBackendPortNumber));
                 return cSharpBackendPortNumber;
             }
@@ -196,7 +200,6 @@ namespace Microsoft.Spark.CSharp.Configuration
             {
                 return "CSharpSparkWorker.exe";
             }
-
         }
     }
 

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -156,11 +156,23 @@ namespace Microsoft.Spark.CSharp.Configuration
             internal override string GetCSharpWorkerPath()
             {
                 KeyValueConfigurationElement workerPathConfig = appSettings.Settings["CSharpWorkerPath"];
+                string workerPath;
                 if (workerPathConfig == null)
                 {
-                    throw new ConfigurationErrorsException("Need to set CSharpWorkerPath value in App.config");
+                    // Path for the CSharpWorker.exe was not specified in App.config
+                    // Try to work out where location relative to this class.
+                    // Construct path based on well-known file name + directory this class was loaded from.
+                    string procFileName = GetCSharpRDDExternalProcessName();
+                    string procDir = Path.GetDirectoryName(GetType().Assembly.Location);
+                    workerPath = Path.Combine(procDir, procFileName);
+                    //throw new ConfigurationErrorsException("Need to set CSharpWorkerPath value in App.config");
                 }
-                return new Uri(workerPathConfig.Value).ToString();
+                else
+                {
+                    // Explicit path for the CSharpWorker.exe was listed in App.config
+                    workerPath = workerPathConfig.Value;
+                }
+                return new Uri(workerPath).ToString();
             }
         }
 

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/ConfigurationService.cs
@@ -91,15 +91,19 @@ namespace Microsoft.Spark.CSharp.Configuration
         /// </summary>
         private class SparkCLRConfiguration
         {
-            protected AppSettingsSection appSettings;
-            private string sparkCLRHome = Environment.GetEnvironmentVariable("SPARKCLR_HOME"); //set by sparkclr-submit.cmd
-            protected ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(SparkCLRConfiguration));
+            protected readonly AppSettingsSection appSettings;
+            private readonly string sparkCLRHome = Environment.GetEnvironmentVariable("SPARKCLR_HOME"); //set by sparkclr-submit.cmd
+            protected readonly ILoggerService logger = LoggerServiceFactory.GetLogger(typeof(SparkCLRConfiguration));
+
             internal SparkCLRConfiguration(System.Configuration.Configuration configuration)
             {
                 appSettings = configuration.AppSettings;
             }
 
-            internal virtual  int GetPortNumber()
+            /// <summary>
+            /// The port number used for communicating with the CSharp external backend worker process.
+            /// </summary>
+            internal virtual int GetPortNumber()
             {
                 int portNo;
                 if (!int.TryParse(Environment.GetEnvironmentVariable("CSHARPBACKEND_PORT"), out portNo))
@@ -111,17 +115,26 @@ namespace Microsoft.Spark.CSharp.Configuration
                 return portNo;
             }
 
+            /// <summary>
+            /// The short-name (filename part) of the CSharp external backend worker process.
+            /// </summary>
             internal virtual string GetCSharpRDDExternalProcessName()
             {
                 //SparkCLR jar and driver, worker & dependencies are shipped using Spark file server. These files available in spark executing directory at executor
                 return "CSharpWorker.exe";
             }
 
+            /// <summary>
+            /// The full path of the CSharp external backend worker process.
+            /// </summary>
             internal virtual string GetCSharpWorkerPath()
             {
                 return new Uri(GetSparkCLRArtifactsPath("bin", "CSharpWorker.exe")).ToString();
             }
 
+            /// <summary>
+            /// List of the files required for the CSharp external backend worker process.
+            /// </summary>
             //this works for Standlone cluster //TODO fix for YARN support
             internal virtual IEnumerable<string> GetDriverFiles()
             {
@@ -203,7 +216,7 @@ namespace Microsoft.Spark.CSharp.Configuration
                 KeyValueConfigurationElement portConfig = appSettings.Settings["CSharpBackendPortNumber"];
                 if (portConfig == null)
                 {
-                    throw new ConfigurationErrorsException("Need to set CSharpBackendPortNumber value in App.config");
+                    throw new ConfigurationErrorsException("Need to set CSharpBackendPortNumber value in App.config for running in DEBUG mode.");
                 }
                 int cSharpBackendPortNumber = int.Parse(portConfig.Value);
                 logger.LogInfo(string.Format("CSharpBackend port number read from app config {0}", cSharpBackendPortNumber));

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
@@ -14,9 +14,21 @@ namespace Microsoft.Spark.CSharp.Configuration
     /// </summary>
     internal interface IConfigurationService
     {
+        /// <summary>
+        /// The port number used for communicating with the CSharp external backend worker process.
+        /// </summary>
         int BackendPortNumber { get; }
+        /// <summary>
+        /// The short-name (filename part) of the CSharp external backend worker process.
+        /// </summary>
         string GetCSharpRDDExternalProcessName();
+        /// <summary>
+        /// The full path of the CSharp external backend worker process.
+        /// </summary>
         string GetCSharpWorkerPath();
+        /// <summary>
+        /// List of the files required for the CSharp external backend worker process.
+        /// </summary>
         IEnumerable<string> GetDriverFiles();
     }
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
@@ -19,13 +19,9 @@ namespace Microsoft.Spark.CSharp.Configuration
         /// </summary>
         int BackendPortNumber { get; }
         /// <summary>
-        /// The short-name (filename part) of the CSharp external backend worker process.
+        /// The full path of the CSharp external backend worker process executable.
         /// </summary>
-        string GetCSharpRDDExternalProcessName();
-        /// <summary>
-        /// The full path of the CSharp external backend worker process.
-        /// </summary>
-        string GetCSharpWorkerPath();
+        string GetCSharpWorkerExePath();
         /// <summary>
         /// List of the files required for the CSharp external backend worker process.
         /// </summary>

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs
@@ -142,7 +142,11 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
 
         public void Dispose()
         {
-            socket.Dispose();
+            if (socket != null)
+            {
+                socket.Dispose();
+                socket = null;
+            }
         }
     }
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/SparkCLRSocket.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/SparkCLRSocket.cs
@@ -101,7 +101,11 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
 
         public void Dispose()
         {
-            socket.Dispose();
+            if (socket != null)
+            {
+                socket.Dispose();
+                socket = null;
+            }
         }
 
         public void Flush()

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkContextIpcProxy.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                 new object[]
                 {
                     rdd, command, hashTableReference, arrayListReference, preservesPartitioning, 
-                    SparkCLREnvironment.ConfigurationService.GetCSharpRDDExternalProcessName(),
+                    SparkCLREnvironment.ConfigurationService.GetCSharpWorkerExePath(),
                     "1.0",
                     jbroadcastVariables, jvmAccumulatorReference
                 });
@@ -306,7 +306,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                 new object[]
                 {
                     name, command, hashTableReference, arrayListReference, 
-                    SparkCLREnvironment.ConfigurationService.GetCSharpRDDExternalProcessName(),
+                    SparkCLREnvironment.ConfigurationService.GetCSharpWorkerExePath(),
                     "1.0",
                     jbroadcastVariables, jvmAccumulatorReference, jDataType
                 }));

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SqlContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SqlContextIpcProxy.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                 new object[]
                 {
                     name, command, hashTableReference, arrayListReference, 
-                    SparkCLREnvironment.ConfigurationService.GetCSharpRDDExternalProcessName(),
+                    SparkCLREnvironment.ConfigurationService.GetCSharpWorkerExePath(),
                     "1.0",
                     arrayListReference, null, "\"" + returnType + "\""
                 });

--- a/csharp/AdapterTest/Mocks/MockConfigurationService.cs
+++ b/csharp/AdapterTest/Mocks/MockConfigurationService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,9 +21,13 @@ namespace AdapterTest.Mocks
         }
 
         private string workerPath;
-        public string GetCSharpRDDExternalProcessName()
+        public string GetCSharpWorkerPath()
         {
             return workerPath;
+        }
+        public string GetCSharpRDDExternalProcessName()
+        {
+            return Path.GetFileName(workerPath);
         }
 
         public int BackendPortNumber
@@ -34,12 +39,6 @@ namespace AdapterTest.Mocks
         {
             get { throw new NotImplementedException(); }
         }
-
-        public string GetCSharpWorkerPath()
-        {
-            return "";
-        }
-
 
         public IEnumerable<string> GetDriverFiles()
         {

--- a/csharp/AdapterTest/Mocks/MockConfigurationService.cs
+++ b/csharp/AdapterTest/Mocks/MockConfigurationService.cs
@@ -21,13 +21,9 @@ namespace AdapterTest.Mocks
         }
 
         private string workerPath;
-        public string GetCSharpWorkerPath()
+        public string GetCSharpWorkerExePath()
         {
             return workerPath;
-        }
-        public string GetCSharpRDDExternalProcessName()
-        {
-            return Path.GetFileName(workerPath);
         }
 
         public int BackendPortNumber


### PR DESCRIPTION
Minor improvements to handling some error conditions and first-use confusion points.

Improved error reporting of missing `CSharpWorkerPath` App.config value.

- Throw `ConfigurationErrorsException` with more specific message about missing `CSharpWorkerPath` value in `App.config`.

~~For Local configuration, use the file name part of the `CSharpWorkerPath` value, if specified,
  otherwise use the default value `CSharpWorker.exe` from base class.~~

Guard against `NullReferenceException` in `Dispose()`.

~~Add `GetJavaPort` method to prompt user for port number and read console.~~
