### PR TITLE
Meta Build Script and Run Samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ csharp/Worker/Microsoft.Spark.CSharp/bin/**
 csharp/Worker/Microsoft.Spark.CSharp/obj/**
 scala/.idea/**
 run/
+*.log
+lib/

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ csharp/Samples/Microsoft.Spark.CSharp/obj/**
 csharp/Worker/Microsoft.Spark.CSharp/bin/**
 csharp/Worker/Microsoft.Spark.CSharp/obj/**
 scala/.idea/**
+run/

--- a/Build.cmd
+++ b/Build.cmd
@@ -1,0 +1,39 @@
+@setlocal
+@echo OFF
+
+SET CMDHOME=%~dp0
+@REM Remove trailing backslash \
+set CMDHOME=%CMDHOME:~0,-1%
+
+set SPARKCLR_HOME=%CMDHOME%\run
+@echo SPARKCLR_HOME=%SPARKCLR_HOME%
+
+if NOT EXIST "%SPARKCLR_HOME%" mkdir "%SPARKCLR_HOME%"
+if NOT EXIST "%SPARKCLR_HOME%\bin" mkdir "%SPARKCLR_HOME%\bin"
+if NOT EXIST "%SPARKCLR_HOME%\data" mkdir "%SPARKCLR_HOME%\data"
+if NOT EXIST "%SPARKCLR_HOME%\lib" mkdir "%SPARKCLR_HOME%\lib"
+if NOT EXIST "%SPARKCLR_HOME%\samples" mkdir "%SPARKCLR_HOME%\samples"
+if NOT EXIST "%SPARKCLR_HOME%\scripts" mkdir "%SPARKCLR_HOME%\scripts"
+
+@echo Assemble SparkCLR Scala components
+pushd "%CMDHOME%\scala"
+call mvn.cmd package
+@echo SparkCLR Scala binaries
+copy /y target\*.jar "%SPARKCLR_HOME%\lib\"
+popd
+
+@echo Assemble SparkCLR C# components
+pushd "%CMDHOME%\csharp"
+call Build.cmd
+@echo SparkCLR C# binaries
+copy /y Worker\Microsoft.Spark.CSharp\bin\Release\* "%SPARKCLR_HOME%\bin\"
+@echo SparkCLR C# Samples binaries
+copy /y Samples\Microsoft.Spark.CSharp\bin\Release\* "%SPARKCLR_HOME%\samples\"
+@echo SparkCLR Samples data
+copy /y Samples\Microsoft.Spark.CSharp\data\* "%SPARKCLR_HOME%\data\"
+popd
+
+@echo Assemble SparkCLR script components
+pushd "%CMDHOME%\scripts"
+copy /y *.cmd  "%SPARKCLR_HOME%\scripts\"
+popd

--- a/Build.cmd
+++ b/Build.cmd
@@ -22,6 +22,15 @@ call mvn.cmd package
 copy /y target\*.jar "%SPARKCLR_HOME%\lib\"
 popd
 
+@REM Any .jar files under the lib directory will be copied to the staged runtime lib tree.
+if EXIST "%CMDHOME%\lib" (
+  @echo Copy extra jar library binaries
+  FOR /F "tokens=*" %%G IN ('DIR /B /A-D /S %CMDHOME%\lib\*.jar') DO (
+    @echo %%G
+    copy /y "%%G" "%SPARKCLR_HOME%\lib\"
+  )
+)
+
 @echo Assemble SparkCLR C# components
 pushd "%CMDHOME%\csharp"
 call Build.cmd

--- a/RunSamples.cmd
+++ b/RunSamples.cmd
@@ -1,0 +1,25 @@
+@setlocal
+@echo OFF
+
+SET CMDHOME=%~dp0
+@REM Remove trailing backslash \
+set CMDHOME=%CMDHOME:~0,-1%
+
+set SPARKCLR_HOME=%CMDHOME%\run
+set SPARKCSV_JARS=
+
+set TEMP_DIR=%SPARKCLR_HOME%\Temp
+if NOT EXIST "%TEMP_DIR%" mkdir "%TEMP_DIR%"
+set SAMPLES_DIR=%SPARKCLR_HOME%\samples
+
+@echo JAVA_HOME=%JAVA_HOME%
+@echo SPARK_HOME=%SPARK_HOME%
+@echo SPARKCLR_HOME=%SPARKCLR_HOME%
+@echo SPARKCSV_JARS=%SPARKCSV_JARS%
+
+cd %SPARKCLR_HOME%
+@cd
+
+@echo ON
+
+%SPARKCLR_HOME%\scripts\sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data


### PR DESCRIPTION
This is my attempt to create a top-level meta-build script, which runs the scala and csharp builds to create those sub-component, and then assembles all the runtime binaries and samples into a `run` directory with the structure defined in the [README](https://github.com/Microsoft/SparkCLR/blob/master/README.md)

In addition, any extra `*.jar` libraries placed into the top level `lib` directory will be copies into the `run\lib` directory too. This is great for handling the extra csv libraries required for the DataFrame TextFile API.

Finally, a `RunSamples.cmd` script provides a simplified way to run through all the SparkCLR Sample using the staged `run` directory tree created above.

Please take a look and see if I this creates the expected runtime artifacts.

For reference, below is the runtime artifacts tree created from using this Build.cmd script on my machine (including the additional `commons-csv-1.2.jar` and `spark-csv_2.10-1.2.0.jar` files which I downloaded manually into `lib`)

```
>dir/s/b run

E:\Depot\GitHub\SparkCLR\run\bin
E:\Depot\GitHub\SparkCLR\run\data
E:\Depot\GitHub\SparkCLR\run\lib
E:\Depot\GitHub\SparkCLR\run\samples
E:\Depot\GitHub\SparkCLR\run\scripts
E:\Depot\GitHub\SparkCLR\run\Temp
E:\Depot\GitHub\SparkCLR\run\bin\CSharpWorker.exe
E:\Depot\GitHub\SparkCLR\run\bin\CSharpWorker.pdb
E:\Depot\GitHub\SparkCLR\run\bin\log4net.dll
E:\Depot\GitHub\SparkCLR\run\bin\log4net.xml
E:\Depot\GitHub\SparkCLR\run\bin\Microsoft.Spark.CSharp.Adapter.dll
E:\Depot\GitHub\SparkCLR\run\bin\Microsoft.Spark.CSharp.Adapter.pdb
E:\Depot\GitHub\SparkCLR\run\bin\Newtonsoft.Json.dll
E:\Depot\GitHub\SparkCLR\run\bin\Newtonsoft.Json.xml
E:\Depot\GitHub\SparkCLR\run\bin\Razorvine.Pyrolite.dll
E:\Depot\GitHub\SparkCLR\run\bin\Razorvine.Serpent.dll
E:\Depot\GitHub\SparkCLR\run\data\csvtestlog.txt
E:\Depot\GitHub\SparkCLR\run\data\market.tab
E:\Depot\GitHub\SparkCLR\run\data\metricslog.txt
E:\Depot\GitHub\SparkCLR\run\data\order.json
E:\Depot\GitHub\SparkCLR\run\data\people.json
E:\Depot\GitHub\SparkCLR\run\data\requestslog.txt
E:\Depot\GitHub\SparkCLR\run\data\words.txt
E:\Depot\GitHub\SparkCLR\run\lib\commons-csv-1.2.jar
E:\Depot\GitHub\SparkCLR\run\lib\spark-clr-1.4.1-SNAPSHOT.jar
E:\Depot\GitHub\SparkCLR\run\lib\spark-csv_2.10-1.2.0.jar
E:\Depot\GitHub\SparkCLR\run\samples\CSharpWorker.exe
E:\Depot\GitHub\SparkCLR\run\samples\CSharpWorker.pdb
E:\Depot\GitHub\SparkCLR\run\samples\log4net.dll
E:\Depot\GitHub\SparkCLR\run\samples\log4net.xml
E:\Depot\GitHub\SparkCLR\run\samples\Microsoft.Spark.CSharp.Adapter.dll
E:\Depot\GitHub\SparkCLR\run\samples\Microsoft.Spark.CSharp.Adapter.pdb
E:\Depot\GitHub\SparkCLR\run\samples\Newtonsoft.Json.dll
E:\Depot\GitHub\SparkCLR\run\samples\Newtonsoft.Json.xml
E:\Depot\GitHub\SparkCLR\run\samples\Razorvine.Pyrolite.dll
E:\Depot\GitHub\SparkCLR\run\samples\SparkCLRSamples.exe
E:\Depot\GitHub\SparkCLR\run\samples\SparkCLRSamples.exe.config
E:\Depot\GitHub\SparkCLR\run\samples\SparkCLRSamples.pdb
E:\Depot\GitHub\SparkCLR\run\scripts\sparkclr-submit.cmd
```