### PR TITLE
RunSamples.cmd could receive arguments

### DIFF
--- a/RunSamples.cmd
+++ b/RunSamples.cmd
@@ -22,4 +22,4 @@ cd %SPARKCLR_HOME%
 
 @echo ON
 
-%SPARKCLR_HOME%\scripts\sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data
+%SPARKCLR_HOME%\scripts\sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data %*

--- a/scala/src/main/org/apache/spark/launcher/SparkCLRSubmitArguments.scala
+++ b/scala/src/main/org/apache/spark/launcher/SparkCLRSubmitArguments.scala
@@ -366,7 +366,7 @@ class SparkCLRSubmitArguments(args: Seq[String], env: Map[String, String], exitF
    */
   private def printUsageAndExit(exitCode: Int = 1): Unit = {
     printStream.println(
-      """Usage: sparkclr-submit [options] -exe <driver.exe> <app zip file | app directory> [app arguments]
+      """Usage: sparkclr-submit [options] <app zip file | app directory> [app arguments]
         |
         |Options:
         |


### PR DESCRIPTION
1. Extra arguments can be passed to RunSamples.cmd.
2. Now single sample can be launched by 'RunSamples.cmd sparkclr.samples.torun <SampleName>'.
3. Options that is supported by SparkCLRSamples.exe can also be supported by RunSamples.cmd automatically.