### PR TITLE
Update README.md, add two extra enviroment variables in `Running Samples` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ The following environment variables should be set properly:
 
 * `JAVA_HOME`
 
-* `SCALA_HOME`  
+* `SPARK_HOME` currently SparkCLR only supports Spark 1.4.x.
+
+* `HADOOP_HOME` hadoop version should be consistent with spark version. For example, if spark build version is spark-1.4.1-bin-hadoop2.6, then only hadoop release 2.6.x should be used.
 
 * `SPARKCSV_JARS` should include full paths to `commons-csv*.jar`, `spark-csv*.jar` for CSV and kafka*.jar, metrics-core*.jar, spark-streaming-kafka*.jar for Kafka. 
 


### PR DESCRIPTION
1. Add env variable `SPARK_HOME`, explicitly point out which version of Spark currently SparkCLR supports.
2. Add env variable `HADOOP_HOME`. As SPARK-2356 is still unresolved, `java.io.IOException: Could not locate executable null\bin\winutils.exe in the Hadoop binaries` will happen if user runs samples on local Windows machine. There are probably many workarounds for this issue, here just choose a simple one for user to follow.
3. Remove unused env variable `SCALA_HOME`