### PR TITLE
Microsoft.VisualStudio.QualityTools.UnitTestFramework not found at runtime

### DIFF
--- a/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
@@ -33,7 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Microsoft.VisualStudio.QualityTools.UnitTestFramework is not part of .Net Framework (just part of VS IDE); by enabling "Copy Local" to true in the reference, the DLL will be included as part of final build, which avoids the exception of missing UnitTestFramework.dll when running on servers without VS IDE installed.

Running "sparkclr.samples.torun PiSample" in the cluster without VS IDE installed repro's this issue.