### PR TITLE
Fix `CSharpWorkerExePath` does not exist issue in standalone mode & code clean up

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Configuration/IConfigurationService.cs
@@ -22,9 +22,5 @@ namespace Microsoft.Spark.CSharp.Configuration
         /// The full path of the CSharp external backend worker process executable.
         /// </summary>
         string GetCSharpWorkerExePath();
-        /// <summary>
-        /// List of the files required for the CSharp external backend worker process.
-        /// </summary>
-        IEnumerable<string> GetDriverFiles();
     }
 }


### PR DESCRIPTION
* Fixed `CSharpWorkerExePath` does not exist in standalone mode issue, now the returned value for `CSharpWorkerExePath` is changed back to `CSharpWorker.exe` for standalone mode.
* Make the `procFileName` (CSharpWorker.exe) as the default value for `CSharpWorkerExePath`, remove class SparkCLRYarnConfiguration.
* Remove unused method `GetDriverFiles()` from interface `IConfigurationService` and classes implemented `IConfigurationService`.
* When call method `GetCSharpWorkerExePath()` in class `SparkCLRDebugConfiguration`,  setting item `CSharpWorkerPath` in App.config will be returned if it is set, this is aligned with `Debugging Tips` section in `README.md`.