### PR TITLE
fix accumulator id and refactor dstream jvm reference

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/Accumulator.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/Accumulator.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Net;
 using System.Net.Sockets;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Reflection;
@@ -17,6 +18,7 @@ using System.Reflection;
 using Microsoft.Spark.CSharp.Interop.Ipc;
 using Microsoft.Spark.CSharp.Services;
 
+[assembly: InternalsVisibleTo("CSharpWorker")]
 namespace Microsoft.Spark.CSharp.Core
 {
     /// <summary>
@@ -35,7 +37,7 @@ namespace Microsoft.Spark.CSharp.Core
     [Serializable]
     public class Accumulator
     {
-        public static Dictionary<int, Accumulator> accumulatorRegistry = new Dictionary<int, Accumulator>();
+        internal static Dictionary<int, Accumulator> accumulatorRegistry = new Dictionary<int, Accumulator>();
 
         protected int accumulatorId;
         [NonSerialized]
@@ -45,11 +47,12 @@ namespace Microsoft.Spark.CSharp.Core
     public class Accumulator<T> : Accumulator
     {
         [NonSerialized]
-        private T value;
+        internal T value;
         private readonly AccumulatorParam<T> accumulatorParam = new AccumulatorParam<T>();
 
         internal Accumulator(int accumulatorId, T value)
         {
+            this.accumulatorId = accumulatorId;
             this.value = value;
             deserialized = false;
             accumulatorRegistry[accumulatorId] = this;
@@ -64,7 +67,7 @@ namespace Microsoft.Spark.CSharp.Core
                 {
                     throw new ArgumentException("Accumulator.value cannot be accessed inside tasks");
                 }
-                return value;
+                return (Accumulator.accumulatorRegistry[accumulatorId] as Accumulator<T>).value;
             }
             // Sets the accumulator's value; only usable in driver program
             set

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkCLRIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkCLRIpcProxy.cs
@@ -13,6 +13,9 @@ using Microsoft.Spark.CSharp.Interop;
 
 namespace Microsoft.Spark.CSharp.Proxy.Ipc
 {
+    /// <summary>
+    /// calling SparkCLR jvm side API
+    /// </summary>
     internal class SparkCLRIpcProxy : ISparkCLRProxy
     {
         private SparkContextIpcProxy sparkContextProxy;
@@ -87,21 +90,20 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
 
         public IDStreamProxy CreateCSharpDStream(IDStreamProxy jdstream, byte[] func, string deserializer)
         {
-            return new DStreamIpcProxy(
-                SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpDStream",
-                new object[] { (jdstream as DStreamIpcProxy).jvmDStreamReference, func, deserializer })
-            );
+            var jvmDStreamReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpDStream",
+                new object[] { (jdstream as DStreamIpcProxy).jvmDStreamReference, func, deserializer });
+
+            var javaDStreamReference = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmDStreamReference, "asJavaDStream"));
+            return new DStreamIpcProxy(javaDStreamReference, jvmDStreamReference);
         }
 
         public IDStreamProxy CreateCSharpTransformed2DStream(IDStreamProxy jdstream, IDStreamProxy jother, byte[] func, string deserializer, string deserializerOther)
         {
-            var dstream = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod((jdstream as DStreamIpcProxy).jvmDStreamReference, "dstream"));
-            var dother = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod((jother as DStreamIpcProxy).jvmDStreamReference, "dstream"));
+            var jvmDStreamReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpTransformed2DStream",
+                new object[] { (jdstream as DStreamIpcProxy).jvmDStreamReference, (jother as DStreamIpcProxy).jvmDStreamReference, func, deserializer, deserializerOther });
 
-            return new DStreamIpcProxy(
-                SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpTransformed2DStream",
-                new object[] { dstream, dother, func, deserializer, deserializerOther })
-            );
+            var javaDStreamReference = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmDStreamReference, "asJavaDStream"));
+            return new DStreamIpcProxy(javaDStreamReference, jvmDStreamReference);
         }
 
         public IDStreamProxy CreateCSharpReducedWindowedDStream(IDStreamProxy jdstream, byte[] func, byte[] invFunc, int windowSeconds, int slideSeconds, string deserializer)
@@ -109,20 +111,20 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
             var windowDurationReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.Duration", new object[] { windowSeconds * 1000 });
             var slideDurationReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.Duration", new object[] { slideSeconds * 1000 });
 
-            return new DStreamIpcProxy(
-                SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpReducedWindowedDStream",
-                new object[] { (jdstream as DStreamIpcProxy).jvmDStreamReference, func, invFunc, windowDurationReference, slideDurationReference, deserializer })
-            );
+            var jvmDStreamReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpReducedWindowedDStream",
+                new object[] { (jdstream as DStreamIpcProxy).jvmDStreamReference, func, invFunc, windowDurationReference, slideDurationReference, deserializer });
+
+            var javaDStreamReference = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmDStreamReference, "asJavaDStream"));
+            return new DStreamIpcProxy(javaDStreamReference, jvmDStreamReference);
         }
 
         public IDStreamProxy CreateCSharpStateDStream(IDStreamProxy jdstream, byte[] func, string deserializer)
         {
-            var dstream = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod((jdstream as DStreamIpcProxy).jvmDStreamReference, "dstream"));
+            var jvmDStreamReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpStateDStream",
+                new object[] { (jdstream as DStreamIpcProxy).jvmDStreamReference, func, deserializer });
 
-            return new DStreamIpcProxy(
-                SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.streaming.api.csharp.CSharpStateDStream",
-                new object[] { dstream, func, deserializer })
-            );
+            var javaDStreamReference = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmDStreamReference, "asJavaDStream"));
+            return new DStreamIpcProxy(javaDStreamReference, jvmDStreamReference);
         }
     }
 }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/DStream.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/DStream.cs
@@ -321,8 +321,7 @@ namespace Microsoft.Spark.CSharp.Streaming
                     other.DStreamProxy, 
                     stream.ToArray(), 
                     serializedMode.ToString(), 
-                    other.serializedMode.ToString()
-                ).AsJavaDStream(), 
+                    other.serializedMode.ToString()), 
                 streamingContext,
                 keepSerializer ? serializedMode : SerializedMode.Byte);
         }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/PairDStreamFunctions.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/PairDStreamFunctions.cs
@@ -300,8 +300,8 @@ namespace Microsoft.Spark.CSharp.Streaming
                     invStream == null ? null : invStream.ToArray(),
                     windowSeconds,
                     slideSeconds,
-                    null
-                ), self.streamingContext
+                    null), 
+                self.streamingContext
             );
         }
 
@@ -331,7 +331,7 @@ namespace Microsoft.Spark.CSharp.Streaming
             return new DStream<KeyValuePair<K, S>>(SparkCLREnvironment.SparkCLRProxy.CreateCSharpStateDStream(
                     self.DStreamProxy,
                     stream.ToArray(),
-                    self.serializedMode.ToString()).AsJavaDStream(),
+                    self.serializedMode.ToString()),
                 self.streamingContext);
         }
     }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/TransformedDStream.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Streaming/TransformedDStream.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Spark.CSharp.Streaming
                     var stream = new MemoryStream();
                     formatter.Serialize(stream, func);
                     dstreamProxy = SparkCLREnvironment.SparkCLRProxy.CreateCSharpDStream(prevDStreamProxy, stream.ToArray(), prevSerializedMode.ToString());
-                    dstreamProxy = dstreamProxy.AsJavaDStream();
                 }
                 return dstreamProxy;
             }

--- a/csharp/Samples/Microsoft.Spark.CSharp/DStreamSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/DStreamSamples.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Spark.CSharp
                     System.Threading.Thread.Sleep(200);
                 }
 
+                System.Threading.Thread.Sleep(3000);
+
                 foreach (var file in Directory.GetFiles(testDir, "*"))
                     File.Delete(file);
             });
@@ -83,14 +85,8 @@ namespace Microsoft.Spark.CSharp
             ssc.Start();
 
             StartFileServer(directory, "words.txt", 100);
-            while (!stopFileServer)
-            {
-                System.Threading.Thread.Sleep(1000);
-            }
 
-            // wait ForeachRDD to complete to let ssc.Stop() gracefully
-            System.Threading.Thread.Sleep(2000);
-
+            ssc.AwaitTermination();
             ssc.Stop();
         }
     }


### PR DESCRIPTION
accumulator id not get passed causing all accumulators having id '0', uses underlying java / scala dstream jvm reference in a consistent way