### PR TITLE
Add callbackSocketShutdown flag to denote whether callback socket is …

### DIFF
--- a/scala/src/main/org/apache/spark/api/csharp/CSharpBackend.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpBackend.scala
@@ -86,6 +86,7 @@ class CSharpBackend {
         val dos = new DataOutputStream(CSharpBackend.callbackSocket.getOutputStream())
         SerDe.writeString(dos, "close")
         CSharpBackend.callbackSocket.close()
+        CSharpBackend.callbackSocketShutdown = true
       }
     }
   }
@@ -94,4 +95,7 @@ class CSharpBackend {
 object CSharpBackend {
   // Channel to callback server.
   private[spark] var callbackSocket: Socket = null
+
+  // flag to denote whether the callback socket is shutdown explicitly
+  @volatile private[spark] var callbackSocketShutdown: Boolean = false
 }

--- a/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala
@@ -57,9 +57,9 @@ class CSharpBackendHandler(server: CSharpBackend) extends SimpleChannelInboundHa
               writeInt(dos, -1)
           }
         case "connectCallback" =>
-		  val t = readObjectType(dis)
-		  assert(t == 'i')
-		  val port = readInt(dis)
+          val t = readObjectType(dis)
+          assert(t == 'i')
+          val port = readInt(dis)
           println("Connecting to a callback server at port " + port)
           CSharpBackend.callbackSocket = new Socket("localhost", port)
           writeInt(dos, 0)
@@ -77,6 +77,7 @@ class CSharpBackendHandler(server: CSharpBackend) extends SimpleChannelInboundHa
             writeInt(dos, 0)
             writeType(dos, "void")
           }
+          CSharpBackend.callbackSocketShutdown = true
         case _ => dos.writeInt(-1)
       }
     } else {

--- a/scala/src/main/org/apache/spark/api/csharp/SerDe.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/SerDe.scala
@@ -192,7 +192,8 @@ object SerDe {
   }
 
   def writeObject(dos: DataOutputStream, value: Object): Unit = {
-    if (value == null) {
+    // for some method invocation, the return type is Unit. Use () to denote Unit here
+    if (value == null || value == ()) {
       writeType(dos, "void")
     } else {
       value.getClass.getName match {


### PR DESCRIPTION
…closed explicitly. Only log exception when the callback socket is not closed explicitly