### PR TITLE
Fix NPE in CSharpRunner

### DIFF
--- a/scala/src/main/org/apache/spark/deploy/csharp/CSharpRunner.scala
+++ b/scala/src/main/org/apache/spark/deploy/csharp/CSharpRunner.scala
@@ -35,9 +35,11 @@ object CSharpRunner {
     var otherArgs: Array[String] = null
 
     if (!runInDebugMode) {
-      if(args(0).toLowerCase().endsWith(".zip")) {
-        println("Unzipping driver!")
-        CSharpSparkUtils.unzip(new File(args(0)), new File(args(0)).getParentFile)
+      if(args(0).toLowerCase.endsWith(".zip")) {
+        val zipFileName = args(0)
+        val driverDir = new File(zipFileName).getAbsoluteFile.getParentFile
+        println(s"Unzipping driver $zipFileName in $driverDir")
+        CSharpSparkUtils.unzip(new File(zipFileName), driverDir)
         csharpExecutable = PythonRunner.formatPath(args(1)) //reusing windows-specific formatting in PythonRunner
         otherArgs = args.slice(2, args.length)
       } else if(new File(args(0)).isDirectory) {


### PR DESCRIPTION
* `getParentFile()` returns `null` if given pathname does not name a parent, call `getAbsoluteFile()` before `getParentFile()` to fix this issue.
* Refine log to include the zip file name as well as driver working directory.