### PR TITLE
clear the clutter in console output when running samples

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -76,8 +76,12 @@ if %ERRORLEVEL% NEQ 0 (
 )
 @echo SparkCLR C# binaries
 copy /y Worker\Microsoft.Spark.CSharp\bin\Release\* "%SPARKCLR_HOME%\bin\"
+
 @echo SparkCLR C# Samples binaries
+rem need to include CSharpWorker.exe.config in samples folder
+copy /y Worker\Microsoft.Spark.CSharp\bin\Release\* "%SPARKCLR_HOME%\samples\"
 copy /y Samples\Microsoft.Spark.CSharp\bin\Release\* "%SPARKCLR_HOME%\samples\"
+
 @echo SparkCLR Samples data
 copy /y Samples\Microsoft.Spark.CSharp\data\* "%SPARKCLR_HOME%\data\"
 popd

--- a/RunSamples.cmd
+++ b/RunSamples.cmd
@@ -1,5 +1,22 @@
 @echo OFF
-setlocal
+setlocal enabledelayedexpansion
+
+set VERBOSE=
+
+:argsloop
+
+if "%1" == "" (
+    rem - no more arguments. 
+) else (
+    rem - check each argument
+    if "%1" == "--verbose" (
+        set VERBOSE="verbose"
+        @echo [RunSamples.cmd] VERBOSE is !VERBOSE!
+    )
+    rem - shift the arguments and examine %1 again
+    shift
+    goto argsloop
+)
 
 @rem check prerequisites
 call precheck.cmd
@@ -10,15 +27,14 @@ if %precheck% == "bad" (goto :eof)
 @rem
 set SPARK_VERSION=1.4.1
 set HADOOP_VERSION=2.6
-@echo SPARK_VERSION=%SPARK_VERSION%
-@echo HADOOP_VERSION=%HADOOP_VERSION%
+@echo [RunSamples.cmd] SPARK_VERSION=%SPARK_VERSION%, HADOOP_VERSION=%HADOOP_VERSION%
 
 @rem Windows 7/8/10 may not allow powershell scripts by default
 powershell -Command Set-ExecutionPolicy Unrestricted
 
 @rem download runtime dependencies
 pushd %~dp0
-powershell -f downloadtools.ps1 run
+powershell -f downloadtools.ps1 run !VERBOSE!
 call tools\updateruntime.cmd
 popd
 
@@ -37,17 +53,14 @@ set TEMP_DIR=%SPARKCLR_HOME%\Temp
 if NOT EXIST "%TEMP_DIR%" mkdir "%TEMP_DIR%"
 set SAMPLES_DIR=%SPARKCLR_HOME%\samples
 
-@echo JAVA_HOME=%JAVA_HOME%
-@echo SPARK_HOME=%SPARK_HOME%
-@echo SPARKCLR_HOME=%SPARKCLR_HOME%
-@echo SPARKCSV_JARS=%SPARKCSV_JARS%
+@echo [RunSamples.cmd] JAVA_HOME=%JAVA_HOME%
+@echo [RunSamples.cmd] SPARK_HOME=%SPARK_HOME%
+@echo [RunSamples.cmd] SPARKCLR_HOME=%SPARKCLR_HOME%
+@echo [RunSamples.cmd] SPARKCSV_JARS=%SPARKCSV_JARS%
 
-pushd %SPARKCLR_HOME%
-@cd
+pushd %SPARKCLR_HOME%\scripts
 
-@echo ON
+@echo [RunSamples.cmd] call sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data %*
+call sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data %*
 
-call %SPARKCLR_HOME%\scripts\sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data %*
-
-@echo OFF
 popd

--- a/csharp/Samples/Microsoft.Spark.CSharp/App.config
+++ b/csharp/Samples/Microsoft.Spark.CSharp/App.config
@@ -11,31 +11,27 @@
     <root>
       <level value="DEBUG" />
       <appender-ref ref="ConsoleAppender" />
-      <!--
       <appender-ref ref="LogFileAppender" />
-      -->
     </root>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="[%date] [%thread] [%-5level] [%logger] - %message%newline" />
       </layout>
     </appender>
-    <!--
     <appender name="LogFileAppender" type="log4net.Appender.RollingFileAppender">
       <file type="log4net.Util.PatternString">
-        <conversionPattern value="C:\\SparkCLRLogs\\SparkCLRSamplesLog_" />
+        <conversionPattern value="%env{TEMP}\\SparkCLRLogs\\SparkCLRSamples_%env{COMPUTERNAME}[%processid].log" />
       </file>
       <param name="AppendToFile" value="true" />
       <param name="MaxSizeRollBackups" value="2000" />
       <param name="MaxFileSize" value="51200000" />
       <param name="StaticLogFileName" value="false" />
-      <param name="DatePattern" value="yyyy_MM_dd_hh_mm" />
+      <param name="DatePattern" value=".yyyy_MM_dd_hh" />
       <param name="RollingStyle" value="Composite" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="[%date] [%thread] [%-5level] [%logger] - %message%newline" />
       </layout>
     </appender>
-   -->
   </log4net>
   
   <appSettings>

--- a/csharp/Worker/Microsoft.Spark.CSharp/App.config
+++ b/csharp/Worker/Microsoft.Spark.CSharp/App.config
@@ -11,31 +11,27 @@
     <root>
       <level value="DEBUG" />
       <appender-ref ref="ConsoleAppender" />
-      <!--
       <appender-ref ref="LogFileAppender" />
-      -->
     </root>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="[%date] [%thread] [%-5level] [%logger] - %message%newline" />
       </layout>
     </appender>
-    <!--
     <appender name="LogFileAppender" type="log4net.Appender.RollingFileAppender">
       <file type="log4net.Util.PatternString">
-        <conversionPattern value="C:\\SparkCLRLogs\\SparkCLRSamplesLog_" />
+        <conversionPattern value="%env{TEMP}\\SparkCLRLogs\\SparkCLRWorker_%env{COMPUTERNAME}[%processid].log" />
       </file>
       <param name="AppendToFile" value="true" />
       <param name="MaxSizeRollBackups" value="2000" />
       <param name="MaxFileSize" value="51200000" />
       <param name="StaticLogFileName" value="false" />
-      <param name="DatePattern" value="yyyy_MM_dd_hh_mm" />
+      <param name="DatePattern" value=".yyyy_MM_dd_hh" />
       <param name="RollingStyle" value="Composite" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="[%date] [%thread] [%-5level] [%logger] - %message%newline" />
       </layout>
     </appender>
-   -->
   </log4net>
 
   <appSettings>

--- a/scripts/spark.conf/executor.log.properties
+++ b/scripts/spark.conf/executor.log.properties
@@ -1,0 +1,18 @@
+# Set everything to be logged to the console
+#log4j.rootCategory=INFO, console, SparkFileAppender
+log4j.rootCategory=INFO, SparkFileAppender
+#log4j.appender.console=org.apache.log4j.ConsoleAppender
+#log4j.appender.console.target=System.out
+#log4j.appender.console.layout=org.apache.log4j.PatternLayout
+#log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+
+log4j.appender.SparkFileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.SparkFileAppender.File=executor.log
+log4j.appender.SparkFileAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.SparkFileAppender.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n

--- a/scripts/spark.conf/log4j.properties
+++ b/scripts/spark.conf/log4j.properties
@@ -1,0 +1,22 @@
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, sparkAppender
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+
+log4j.appender.sparkAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.sparkAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.sparkAppender.File=${env:TEMP}/SparkCLRLogs/spark.log
+log4j.appender.sparkAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sparkAppender.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n
+
+#log4j.appender.SparkFileAppender=org.apache.log4j.RollingFileAppender
+#log4j.appender.SparkFileAppender.File=${env:TEMP}/SparkCLRLogs/spark.log
+#log4j.appender.SparkFileAppender.layout=org.apache.log4j.PatternLayout
+#log4j.appender.SparkFileAppender.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} [%t] %-5p %c - %m%n
+#log4j.appender.SparkFileAppender.MaxFileSize=100MB
+#log4j.appender.SparkFileAppender.MaxBackupIndex=14
+

--- a/scripts/spark.conf/spark-1.4.1-log4j.properties.template
+++ b/scripts/spark.conf/spark-1.4.1-log4j.properties.template
@@ -1,0 +1,12 @@
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO

--- a/scripts/sparkclr-submit.cmd
+++ b/scripts/sparkclr-submit.cmd
@@ -21,7 +21,7 @@ for %%d in (%ASSEMBLY_DIR%\spark-assembly*hadoop*.jar) do (
   set SPARK_ASSEMBLY_JAR=%%d
 )
 if "%SPARK_ASSEMBLY_JAR%"=="0" (
-  echo Failed to find Spark assembly JAR.
+  @echo [sparkclr-submit.cmd] Failed to find Spark assembly JAR.
   exit /b 1
 )
 
@@ -51,7 +51,7 @@ for /f "tokens=*" %%i in (%LAUNCHER_OUTPUT%) do (
 del %LAUNCHER_OUTPUT%
 
 REM launches the Spark job with Spark-Submit.cmd
-echo Command to run %SPARK_ARGS%
+@echo [sparkclr-submit.cmd] Command to run %SPARK_ARGS%
 %SPARK_HOME%/bin/spark-submit.cmd %SPARK_ARGS%
 
 goto :eof
@@ -61,19 +61,19 @@ goto :eof
 goto :eof
 
 :sparkhomeerror
-	@echo Error - SPARK_HOME environment variable is not set
-	@echo Note that SPARK_HOME environment variable should not have trailing \
+	@echo [sparkclr-submit.cmd] Error - SPARK_HOME environment variable is not set
+	@echo [sparkclr-submit.cmd] Note that SPARK_HOME environment variable should not have trailing \
 	goto :eof
 	
 :javahomeerror
-	@echo Error - JAVA_HOME environment variable is not set
-	@echo Note that JAVA_HOME environment variable should not have trailing \
+	@echo [sparkclr-submit.cmd] Error - JAVA_HOME environment variable is not set
+	@echo [sparkclr-submit.cmd] Note that JAVA_HOME environment variable should not have trailing \
 	goto :eof
 	
 :sparkclrhomeerror
-	@echo Error - SPARKCLR_HOME environment variable is not set
-	@echo SPARKCLR_HOME need to be set to the folder path for csharp-spark*.jar
-	@echo Note that SPARKCLR_HOME environment variable should not have trailing \
+	@echo [sparkclr-submit.cmd] Error - SPARKCLR_HOME environment variable is not set
+	@echo [sparkclr-submit.cmd] SPARKCLR_HOME need to be set to the folder path for csharp-spark*.jar
+	@echo [sparkclr-submit.cmd] Note that SPARKCLR_HOME environment variable should not have trailing \
 	goto :eof
 
 :usage

--- a/scripts/zipdir.ps1
+++ b/scripts/zipdir.ps1
@@ -24,18 +24,27 @@ function Zip-Directory($sourceDir, $targetFile)
 {
     if (!(test-path $sourceDir))
     {
-        Write-Output "[Zip-Directory] WARNING!!! $sourceDir does not exist. Please provide a valid directory name !"
+        Write-Output "[zipdir.Zip-Directory] WARNING!!! $sourceDir does not exist. Please provide a valid directory name !"
         return
     }
 
-    if ((test-path $targetFile))
+    while (test-path $targetFile)
     {
-        Write-Output "[Zip-Directory] Delete existing $targetFile"
-        Remove-Item $targetFile
+        try
+        {
+            Write-Output "[zipdir.Zip-Directory] Delete existing $targetFile"
+            remove-item $targetFile -force
+        } 
+        catch [Exception]
+        {
+            Write-Output "[zipdir.Zip-Directory] Delete existing zipFile exception: $_.Exception.GetType().FullName"
+            Write-Output "[zipdir.Zip-Directory] Delete existing zipFile exception: $_.Exception.Message"
+            Start-Sleep -s 1
+        }
     }
 
     $start_time = Get-Date
-    Write-Output "[Zip-Directory] Zip $sourceDir to $targetFile ..."
+    Write-Output "[zipdir.Zip-Directory] Zip $sourceDir to $targetFile ..."
 
     $compressionLevel = [System.IO.Compression.CompressionLevel]::Optimal
     [System.IO.Compression.ZipFile]::CreateFromDirectory(
@@ -57,7 +66,7 @@ function Zip-Directory($sourceDir, $targetFile)
         $howlong = "$seconds seconds"
     }
 
-    Write-Output "[Zip-Directory] $targetFile completed. Time taken: $howlong"
+    Write-Output "[zipdir.Zip-Directory] $targetFile completed. Time taken: $howlong"
 }
 
 function Print-Usage


### PR DESCRIPTION
minor changes across a few files.

Runsamples.cmd accepts "--verbose" flag. By default, FileAppender replaces ConsoleAppender in Spark log4j.properties, SparkCLR App.Config; FileAppender produce logs at %TEMP%\SparkCLRLogs. When "--verbose" flag is added, ConsoleAppenders are enabled, in addition to FileAppender.

Try PiSample to see the difference - 
(1) runsamples --torun pi* 
(2) runsamples --verbose --torun pi*