### PR TITLE
Fix PowerShell System.UnauthorizedAccessException issue when execute RunSamples.cmd

### DIFF
--- a/RunSamples.cmd
+++ b/RunSamples.cmd
@@ -30,7 +30,7 @@ set HADOOP_VERSION=2.6
 @echo [RunSamples.cmd] SPARK_VERSION=%SPARK_VERSION%, HADOOP_VERSION=%HADOOP_VERSION%
 
 @rem Windows 7/8/10 may not allow powershell scripts by default
-powershell -Command Set-ExecutionPolicy Unrestricted
+powershell -Command Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
 
 @rem download runtime dependencies
 pushd %~dp0


### PR DESCRIPTION
* When executed RunSample.cmd on WIndows 10 (Version 10.0.10240 by `ver` command), following error happened:
<pre>
D:\SparkWorkspace\SparkCLR>RunSamples.cmd --validate
SPARK_VERSION=1.4.1
HADOOP_VERSION=2.6
Set-ExecutionPolicy : Access to the registry key
'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell' is denied. To change the execution
policy for the default (LocalMachine) scope, start Windows PowerShell with the "Run as administrator" option. To
change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".
At line:1 char:1
> + Set-ExecutionPolicy Unrestricted
> + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>    + CategoryInfo          : PermissionDenied: (:) [Set-ExecutionPolicy], UnauthorizedAccessException
>    + FullyQualifiedErrorId : System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.SetExecutionPolicyComma
   nd
[downloadtools] hadoopVersion=2.6, sparkVersion=1.4.1
[Download-BuildTools] D:\SparkWorkspace\SparkCLR\tools\TarTool.exe exists already. No download and extraction needed
...
</pre>

* Explicitly set the scope to `CurrentUser` to avoid this exception.