### PR TITLE
[Issue #111]Fix Inconsistent addressing schemes used by sockets in SparkCLR

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Spark.CSharp.Core
         internal IEnumerable<dynamic> Collect(int port)
         {
             IFormatter formatter = new BinaryFormatter();
-            Socket sock = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             sock.Connect("127.0.0.1", port);
 
             using (NetworkStream s = new NetworkStream(sock))


### PR DESCRIPTION
In Microsoft.Spark.CSharp.Core.RDD, method Collect creates a socket without explicitly specifying the AddressFamily, which by default is InterNetworkv6 (ip v6). This also cause "invalid argument" exceptions on Linux when calling collect on RDD.
This is also inconsistent with other places in SpakCLR, e.g., SparkCLRSocket or JvmBridge, where sockets always explicitly use AddressFamily.InterNetwork (ip v4).