### PR TITLE
add runsamples; proceed with build even not dev command prompt for VS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ run/
 tools/
 *.log
 lib/
+target/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,28 +1,12 @@
 version: 1.4.1-SNAPSHOT.{build}
-# install maven and set paths (thanks to http://www.yegor256.com/2015/01/10/windows-appveyor-maven.html)
-install:
-  - ps: |
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
-          'C:\maven-bin.zip'
-        )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-      }
-  - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH%
-  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
-  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
-branches:
-  only:
-    - master
+
 #build C# solution and scala project
 build_script:
-- cmd: >-
-    cd scala
+  - cmd: SET PATH=%JAVA_HOME%\bin;%PATH%
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: Build.cmd
 
-    mvn package
-
-    cd ..\csharp
-
-    Build.cmd
+# scripts to run after tests
+after_test:
+  - cmd: Runsamples.cmd --validate

--- a/precheck.cmd
+++ b/precheck.cmd
@@ -1,14 +1,6 @@
 @echo OFF
 
-set precheck="bad"
-
-set version="unknown"
-
-if "%VisualStudioVersion%" == "" ( goto vstudiowarning)
-
-@REM VS 2013 == Version 12; VS 2015 == Version 14
-set version=%VisualStudioVersion:~0,2%
-if %version% LSS 12 ( goto vstudiowarning)
+set precheck="ok"
 
 if not exist "%JAVA_HOME%\bin\java.exe" (
     @echo. 
@@ -20,10 +12,17 @@ if not exist "%JAVA_HOME%\bin\java.exe" (
     @echo. 
     @echo ============================================================================================
     @echo. 
+    set precheck="bad"
     goto :eof
 )
 
-set precheck="ok"
+set version="unknown"
+if "%VisualStudioVersion%" == "" ( goto vstudiowarning)
+
+@REM VS 2013 == Version 12; VS 2015 == Version 14
+set version=%VisualStudioVersion:~0,2%
+if %version% LSS 12 ( goto vstudiowarning)
+
 goto :eof
 
 :vstudiowarning
@@ -36,5 +35,3 @@ goto :eof
 @echo. 
 @echo ============================================================================================
 @echo. 
-goto :eof
-


### PR DESCRIPTION
This change added complete sample run, with --validate flag, after unit test. It increases build-time at AppVeyor from 5 minute to 13 minutes and 30 seconds. We will observe closely whether the increase in build-time negatively impact the productivity - if it does, we will run selected sample test.