### PR TITLE
Fix RuntimeBinderException in Worker.cs when run samples DFForeachPartitionSample and DFForeachSample

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/DataFrame.cs
@@ -730,10 +730,30 @@ namespace Microsoft.Spark.CSharp.Sql
         /// Returns a new RDD by applying a function to each partition of this DataFrame.
         /// </summary>
         // Python API: https://github.com/apache/spark/blob/branch-1.4/python/pyspark/sql/dataframe.py
-        // mapPartitions(self, f, preservesPartitioning=False):
+        // mapPartitions(self, f, preservesPartitioning=False)
         public RDD<U> MapPartitions<U>(Func<IEnumerable<Row>, IEnumerable<U>> f, bool preservesPartitioning = false)
         {
             return Rdd.MapPartitions(f, preservesPartitioning);
+        }
+
+        /// <summary>
+        /// Applies a function f to each partition of this DataFrame.
+        /// </summary>
+        // Python API: https://github.com/apache/spark/blob/branch-1.4/python/pyspark/sql/dataframe.py
+        // foreachPartition(self, f)
+        public void ForeachPartition(Action<IEnumerable<Row>> f)
+        {
+            Rdd.ForeachPartition(f);
+        }
+
+        /// <summary>
+        /// Applies a function f to all rows.
+        /// </summary>
+        // Python API: https://github.com/apache/spark/blob/branch-1.4/python/pyspark/sql/dataframe.py
+        // foreach(self, f)
+        public void Foreach(Action<Row> f)
+        {
+            Rdd.Foreach(f);
         }
     }
 

--- a/csharp/Samples/Microsoft.Spark.CSharp/DataFrameSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/DataFrameSamples.cs
@@ -1049,5 +1049,25 @@ namespace Microsoft.Spark.CSharp.Samples
                 Assert.AreEqual(dfCount, rddSum);
             }
         }
+
+        /// <summary>
+        /// ForeachPartition sample
+        /// </summary>
+        [Sample]
+        internal static void DFForeachPartitionSample()
+        {
+            var peopleDataFrame = GetSqlContext().JsonFile(SparkCLRSamples.Configuration.GetInputDataPath(PeopleJson));
+            peopleDataFrame.ForeachPartition(iter => { foreach (var row in iter) Console.WriteLine(row); });
+        }
+
+        /// <summary>
+        /// Foreach sample
+        /// </summary>
+        [Sample]
+        internal static void DFForeachSample()
+        {
+            var peopleDataFrame = GetSqlContext().JsonFile(SparkCLRSamples.Configuration.GetInputDataPath(PeopleJson));
+            peopleDataFrame.Foreach(row => { Console.WriteLine(row); });
+        }
     }
 }

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
@@ -141,6 +141,11 @@ namespace Microsoft.Spark.CSharp
                         int count = 0;
                         foreach (var message in func(splitIndex, GetIterator(s, deserializerMode)))
                         {
+                            if (object.ReferenceEquals(null, message)) 
+                            {
+                                    continue;
+                            }
+
                             byte[] buffer;
 
                             if (serializerMode == "None")


### PR DESCRIPTION
* When run samples `DFForeachPartitionSample` and `DFForeachSample`, exception `Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Cannot perform runtime binding on a null reference` happened in `Worker.cs`
* Add null check in `Worker.cs` to prevent this exception
* Add unit tests
