### PR TITLE
SamplesRunner propgates test status to CI

### DIFF
--- a/csharp/Samples/Microsoft.Spark.CSharp/Program.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Program.cs
@@ -26,16 +26,17 @@ namespace Microsoft.Spark.CSharp.Samples
             Configuration = CommandlineArgumentProcessor.ProcessArugments(args);
 
             PrintLogLocation();
+            bool status = true;
             if (Configuration.IsDryrun)
             {
-                SamplesRunner.RunSamples();
+                status = SamplesRunner.RunSamples();
             }
             else
             {
                 SparkContext = CreateSparkContext();
-                SparkContext.SetCheckpointDir(Path.GetTempPath()); 
+                SparkContext.SetCheckpointDir(Path.GetTempPath());
 
-                SamplesRunner.RunSamples();
+                status = SamplesRunner.RunSamples();
 
                 PrintLogLocation();
                 ConsoleWriteLine("Completed running samples. Calling SparkContext.Stop() to tear down ...");
@@ -43,6 +44,11 @@ namespace Microsoft.Spark.CSharp.Samples
                 ConsoleWriteLine("If this program (SparkCLRSamples.exe) does not terminate in 10 seconds, please manually terminate java process launched by this program!!!");
                 //TODO - add instructions to terminate java process
                 SparkContext.Stop();
+            }
+
+            if (Configuration.IsValidationEnabled && !status)
+            {
+                Environment.Exit(1);
             }
         }
 

--- a/csharp/Samples/Microsoft.Spark.CSharp/SamplesRunner.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/SamplesRunner.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Spark.CSharp.Samples
         // track <SampleName, Category, SampleSucceeded, Duration> for reporting
         private static readonly List<Tuple<string, string, bool, TimeSpan>> samplesRunInfoList = new List<Tuple<string, string, bool, TimeSpan>>();
 
-        internal static void RunSamples()
+        internal static bool RunSamples()
         {
             var samples = Assembly.GetEntryAssembly().GetTypes()
                       .SelectMany(type => type.GetMethods(BindingFlags.NonPublic | BindingFlags.Static))
@@ -42,7 +42,7 @@ namespace Microsoft.Spark.CSharp.Samples
                 }
             }
             stopWatch.Stop();
-            ReportOutcome();
+            return ReportOutcome();
         }
 
         private static Tuple<string, string, bool, TimeSpan> RunSample(MethodInfo sample)
@@ -134,7 +134,7 @@ namespace Microsoft.Spark.CSharp.Samples
             return regex;
         }
 
-        private static void ReportOutcome()
+        private static bool ReportOutcome()
         {
             var succeededSamples = samplesRunInfoList.Where(x => x.Item3).ToList();
             var failedSamples = samplesRunInfoList.Where(x => !x.Item3).ToList();
@@ -168,6 +168,8 @@ namespace Microsoft.Spark.CSharp.Samples
                     SparkCLRSamples.WriteColorCodedConsoleMessage(ConsoleColor.Red, sampleResult);
                 }
             }
+
+            return failedSamples.Count == 0;
         }
     }
 }


### PR DESCRIPTION
This fix enables SamplesRunner to propagate out test status, which will fix the after_test task "RunSamples.cmd --validate" in AppVeyor. This PR fixes #134 