### PR TITLE
Update to nunit3 as appveyor is upgraded

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ build_script:
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: Build.cmd
 
+test:
+  assemblies:
+    - csharp\AdapterTest\bin\Debug\AdapterTest.dll
+
 # scripts to run after tests
 after_test:
   - cmd: Runsamples.cmd --validate

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Razorvine.Pyrolite">

--- a/csharp/AdapterTest/ComparableRDDTest.cs
+++ b/csharp/AdapterTest/ComparableRDDTest.cs
@@ -12,7 +12,7 @@ namespace AdapterTest
     {
         private static RDD<string> words;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void Initialize()
         {
             var sparkContext = new SparkContext(null);

--- a/csharp/AdapterTest/DataFrameTest.cs
+++ b/csharp/AdapterTest/DataFrameTest.cs
@@ -25,7 +25,7 @@ namespace AdapterTest
 
         private static Mock<IDataFrameProxy> mockDataFrameProxy;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void ClassInitialize()
         {
             mockDataFrameProxy = new Mock<IDataFrameProxy>();

--- a/csharp/AdapterTest/DoubleRDDTest.cs
+++ b/csharp/AdapterTest/DoubleRDDTest.cs
@@ -13,7 +13,7 @@ namespace AdapterTest
     {
         private static RDD<double> doubles;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void Initialize()
         {
             var sparkContext = new SparkContext(null);

--- a/csharp/AdapterTest/PairRDDTest.cs
+++ b/csharp/AdapterTest/PairRDDTest.cs
@@ -13,7 +13,7 @@ namespace AdapterTest
     {
         private static RDD<KeyValuePair<string, int>> pairs;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void Initialize()
         {
             var sparkContext = new SparkContext(null);

--- a/csharp/AdapterTest/RDDTest.cs
+++ b/csharp/AdapterTest/RDDTest.cs
@@ -19,7 +19,7 @@ namespace AdapterTest
     {
         private static RDD<string> words;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public static void Initialize()
         {
             var sparkContext = new SparkContext(null);

--- a/csharp/AdapterTest/SparkCLRTestEnvironment.cs
+++ b/csharp/AdapterTest/SparkCLRTestEnvironment.cs
@@ -19,7 +19,7 @@ namespace AdapterTest
     [SetUpFixture]
     public class SparkCLRTestEnvironment 
     {
-        [SetUp]
+        [OneTimeSetUp]
         public static void Initialize()
         {
             SparkCLREnvironment.SparkCLRProxy = new MockSparkCLRProxy();

--- a/csharp/AdapterTest/packages.config
+++ b/csharp/AdapterTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.0.1" targetFramework="net45" />
   <package id="Razorvine.Pyrolite" version="4.10.0.0" targetFramework="net45" />
   <package id="Razorvine.Serpent" version="1.12.0.0" targetFramework="net45" />
 </packages>

--- a/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Samples.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/csharp/Samples/Microsoft.Spark.CSharp/packages.config
+++ b/csharp/Samples/Microsoft.Spark.CSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update unit test to use NUnit3, as AppVeyor is upgraded to use NUnit3.
Explicitly set assemblies to test, as AppVeyor test auto-detection will detect SparkCLRSamples.exe but fail to find any testfixtures in it.