### PR TITLE
Set executable name as app name when app.name is not explicitly set

### DIFF
--- a/scala/src/main/org/apache/spark/launcher/SparkCLRSubmitArguments.scala
+++ b/scala/src/main/org/apache/spark/launcher/SparkCLRSubmitArguments.scala
@@ -41,6 +41,8 @@ class SparkCLRSubmitArguments(args: Seq[String], env: Map[String, String], exitF
 
   var mainExecutable: String = null
 
+  var appName: String = null;
+
   var master: String = null
 
   var deployMode: String = "client"
@@ -123,6 +125,9 @@ class SparkCLRSubmitArguments(args: Seq[String], env: Map[String, String], exitF
 
       case MASTER =>
         master = value
+
+      case NAME =>
+        appName = value
 
       case PROPERTIES_FILE =>
         propertiesFile = value
@@ -224,6 +229,8 @@ class SparkCLRSubmitArguments(args: Seq[String], env: Map[String, String], exitF
   }
 
   private def concatCmdOptions(): Unit = {
+
+    if (appName == null) cmd = cmd.trim + s" --name " + mainExecutable.stripSuffix(".exe")
 
     //figure out deploy mode
     deployMode = Option(deployMode).orElse(env.get("DEPLOY_MODE")).orNull

--- a/scala/src/test/scala/org/apache/spark/launcher/SparkCLRSubmitArgumentsSuite.scala
+++ b/scala/src/test/scala/org/apache/spark/launcher/SparkCLRSubmitArgumentsSuite.scala
@@ -308,4 +308,40 @@ class SparkCLRSubmitArgumentsSuite extends SparkCLRFunSuite with Matchers with T
       " " +
       args.mkString(" ")
   }
+
+  test("handle the case that app name is not specified") {
+    val remoteDriverPath = "hdfs://host:port/path/to/driver.zip"
+    val executableName = "Samples.exe"
+    val deployMode = "cluster"
+    val master = "spark://host:port"
+    val files = "hdfs://path/to/file1,hdfs://path/to/file2"
+    val jars = "hdfs://path/to/1.jar,hdfs://path/to/2.jar"
+    val remoteSparkClrJarPath = "hdfs://path/to/sparkclr.jar"
+    val args = Array("arg1", "arg2")
+
+    val clArgs = Array(
+      "--deploy-mode", deployMode,
+      "--master", master,
+      "--files", files,
+      "--jars", jars,
+      "--exe", executableName,
+      remoteSparkClrJarPath,
+      remoteDriverPath
+    ) ++ args
+
+    val options = new SparkCLRSubmitArguments(clArgs, Map()).buildCmdOptions()
+
+    val expectedAppName = executableName.stripSuffix(".exe")
+    options should fullyMatch regex
+        s" --deploy-mode $deployMode" +
+        s" --master $master" +
+        s" --name $expectedAppName" +
+        s" --jars $jars,$remoteSparkClrJarPath" +
+        s" --files $files,$remoteDriverPath" +
+        s" --class $csharpRunnerClass $remoteSparkClrJarPath" +
+        s" $remoteDriverPath" +
+        s" $executableName" +
+        " " +
+        args.mkString(" ")
+  }
 }


### PR DESCRIPTION
This PR is trying to fix #147 