### PR TITLE
Enable '--remote-sparkclr-jar' option for standalone cluster mode

### DIFF
--- a/linux-instructions.md
+++ b/linux-instructions.md
@@ -91,6 +91,7 @@ A few more [run-samples.sh](./run-samples.sh) examples:
 ```
 sparkclr-submit.sh --verbose --master spark://host:port --exe SparkCLRSamples.exe  $SPARKCLR_HOME/samples sparkclr.sampledata.loc hdfs://path/to/sparkclr/sampledata
 ```
+- When option `--deploy-mode` is specified with `cluster`, option `--remote-sparkclr-jar` is required and needs to be specified with a valid file path of spark-clr*.jar on HDFS.
 
 ## Running in YARN mode
 

--- a/scripts/sparkclr-submit.cmd
+++ b/scripts/sparkclr-submit.cmd
@@ -83,3 +83,5 @@ goto :eof
 	@echo sparkclr-submit.cmd [--verbose] [--master local] [--deploy-mode client] [--name testapp] --exe csdriver.exe c:\sparkclrapp\driver arg1 arg2 arg3
 	@echo Example 2:
 	@echo sparkclr-submit.cmd [--verbose] [--master local] [--deploy-mode client] [--name testapp] --exe csdriver.exe c:\sparkclrapp\driver.zip arg1 arg2 arg3
+	@echo Example 3:
+	@echo sparkclr-submit.cmd [--verbose] --master spark://host:port --deploy-mode cluster [--name testapp] --exe csdriver.exe --remote-sparkclr-jar hdfs://path/to/spark-clr-1.4.1-SNAPSHOT.jar hdfs://path/to/driver.zip arg1 arg2 arg3

--- a/scripts/sparkclr-submit.sh
+++ b/scripts/sparkclr-submit.sh
@@ -26,6 +26,8 @@ function usage() {
 	echo "sparkclr-submit.sh [--verbose] [--master local] [--deploy-mode client] [--name testapp] --exe csdriver.exe sparkclrapp/driver arg1 arg2 arg3"
 	echo "Example 2:"
 	echo "sparkclr-submit.sh [--verbose] [--master local] [--deploy-mode client] [--name testapp] --exe csdriver.exe sparkclrapp/driver.zip arg1 arg2 arg3"
+	echo "Example 3:"
+	echo "sparkclr-submit.sh [--verbose] --master spark://host:port --deploy-mode cluster [--name testapp] --exe csdriver.exe --remote-sparkclr-jar --remote-sparkclr-jar hdfs://path/to/spark-clr-1.4.1-SNAPSHOT.jar hdfs://path/to/driver.zip arg1 arg2 arg3"
 }
 
 [ "$SPARK_HOME" = "" ] && spark_home_error

--- a/windows-instructions.md
+++ b/windows-instructions.md
@@ -84,6 +84,7 @@ A few more [RunSamples.cmd](./RunSamples.cmd) examples:
 ```
 sparkclr-submit.cmd --verbose --master spark://host:port --exe SparkCLRSamples.exe  %SPARKCLR_HOME%\samples sparkclr.sampledata.loc hdfs://path/to/sparkclr/sampledata
 ```
+- When option `--deploy-mode` is specified with `cluster`, option `--remote-sparkclr-jar` is required and needs to be specified with a valid file path of spark-clr*.jar on HDFS.
 
 ## Running in YARN mode
 


### PR DESCRIPTION
* Add new option `--remote-sparkclr-jar` to `sparkclr-submit.cmd`,  this new option is only required for standalone cluster mode.
* When option `--deploy-mode` is specified with `cluster`, option `--remote-sparkclr-jar` is required and needs to be specified with a valid file path of spark-clr*.jar on HDFS.
* Make changes to Windows-instructions.md, Linux-instructions.md and sparkclr-submit.cmd to reflect this change.
* Unit tests