### PR TITLE
MINOR: Clean up and simplify .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,27 +22,13 @@
 
 # Folders #
 ############
-*/target/**
-*/bin/**
-*/obj/**
-csharp/packages
-csharp/Adapter/Microsoft.Spark.CSharp/bin/**
-csharp/Adapter/Microsoft.Spark.CSharp/obj/**
-csharp/AdapterTest/bin/**
-csharp/AdapterTest/obj/**
-csharp/WorkerTest/obj/**
-csharp/WorkerTest/bin/**
-csharp/Samples/Microsoft.Spark.CSharp/bin/**
-csharp/Samples/Microsoft.Spark.CSharp/obj/**
-csharp/Worker/Microsoft.Spark.CSharp/bin/**
-csharp/Worker/Microsoft.Spark.CSharp/obj/**
-csharp/Perf/Microsoft.Spark.CSharp/bin/**
-csharp/Perf/Microsoft.Spark.CSharp/obj/**
-scala/.idea/**
-scala/perf/.idea/**
+**/bin/
+**/obj/
+**/packages/
+**/target/
+**/.idea/
 scala/dependency-reduced-pom.xml
 run/
 tools/
 *.log
 lib/
-target/


### PR DESCRIPTION
- Ignore compiler / IDE temp directories at any depth in the directory tree, rather than individually.

```
  bin
  obj
  packages
  target
  .idea
```