### PR TITLE
MINOR: IPAddress.Loopback

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/Accumulator.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/Accumulator.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Spark.CSharp.Core
         private bool serverShutdown;
 
         internal AccumulatorServer()
-            : base(IPAddress.Parse("127.0.0.1"), 0)
+            : base(IPAddress.Loopback, 0)
         {
 
         }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDDCollector.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDDCollector.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -23,7 +24,7 @@ namespace Microsoft.Spark.CSharp.Core
         {
             IFormatter formatter = new BinaryFormatter();
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.Connect("127.0.0.1", port);
+            sock.Connect(IPAddress.Loopback, port);
 
             using (NetworkStream s = new NetworkStream(sock))
             {

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Interop/Ipc/JvmBridge.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Spark.CSharp.Interop.Ipc
             if (!sockets.TryDequeue(out socket))
             {
                 socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                socket.Connect(IPAddress.Parse("127.0.0.1"), portNumber);
+                socket.Connect(IPAddress.Loopback, portNumber);
             }
             return socket;
         }

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkContextIpcProxy.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Spark.CSharp.Core;
@@ -100,7 +101,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
         {
             jvmAccumulatorReference = new JvmObjectReference((string)SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(jvmJavaContextReference, "accumulator", 
                 SparkCLRIpcProxy.JvmBridge.CallConstructor("java.util.ArrayList"),
-                SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.api.python.PythonAccumulatorParam", "127.0.0.1", port)
+                SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.api.python.PythonAccumulatorParam", IPAddress.Loopback.ToString(), port)
             ));
         }
 

--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StreamingContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StreamingContextIpcProxy.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
 
         public int StartCallback()
         {
-            TcpListener callbackServer = new TcpListener(IPAddress.Parse("127.0.0.1"), 0);
+            TcpListener callbackServer = new TcpListener(IPAddress.Loopback, 0);
             callbackServer.Start();
 
             Task.Run(() =>

--- a/csharp/AdapterTest/Mocks/MockSparkContextProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockSparkContextProxy.cs
@@ -200,7 +200,7 @@ namespace AdapterTest.Mocks
                     return ms.ToArray();
                 });
 
-            TcpListener listener = new TcpListener(IPAddress.Parse("127.0.0.1"), 0);
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
 
             Task.Run(() =>

--- a/csharp/AdapterTest/StreamingContextTest.cs
+++ b/csharp/AdapterTest/StreamingContextTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using AdapterTest.Mocks;
 using Microsoft.Spark.CSharp.Core;
 using Microsoft.Spark.CSharp.Streaming;
@@ -27,10 +28,10 @@ namespace AdapterTest
             var textFile = ssc.TextFileStream(Path.GetTempPath());
             Assert.IsNotNull(textFile.DStreamProxy);
 
-            var socketStream = ssc.SocketTextStream("127.0.0.1", 12345);
+            var socketStream = ssc.SocketTextStream(IPAddress.Loopback.ToString(), 12345);
             Assert.IsNotNull(socketStream.DStreamProxy);
 
-            var kafkaStream = ssc.KafkaStream("127.0.0.1:2181", "testGroupId", new Dictionary<string, int> { { "testTopic1", 1 } }, new Dictionary<string, string>());
+            var kafkaStream = ssc.KafkaStream(IPAddress.Loopback + ":2181", "testGroupId", new Dictionary<string, int> { { "testTopic1", 1 } }, new Dictionary<string, string>());
             Assert.IsNotNull(kafkaStream.DStreamProxy);
 
             var directKafkaStream = ssc.DirectKafkaStream(new List<string> { "testTopic2" }, new Dictionary<string, string>(), new Dictionary<string, long>());

--- a/csharp/AdapterTest/TestWithMoqDemo.cs
+++ b/csharp/AdapterTest/TestWithMoqDemo.cs
@@ -60,7 +60,7 @@ namespace AdapterTest
             _mockSparkCLRProxy.Setup(m => m.CreateStreamingContext(It.IsAny<SparkContext>(), It.IsAny<long>())).Returns(_mockStreamingContextProxy.Object);
             _mockRddProxy.Setup(m => m.CollectAndServe()).Returns(() =>
             {
-                TcpListener listener = new TcpListener(IPAddress.Parse("127.0.0.1"), 0);
+                TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
                 listener.Start();
 
                 Task.Run(() =>

--- a/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
+++ b/csharp/Worker/Microsoft.Spark.CSharp/Worker.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Spark.CSharp
                 int javaPort = int.Parse(Console.ReadLine());
                 logger.LogInfo("java_port: " + javaPort);
                 sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                sock.Connect(IPAddress.Parse("127.0.0.1"), javaPort);
+                sock.Connect(IPAddress.Loopback, javaPort);
             }
             catch (Exception e)
             {

--- a/csharp/WorkerTest/WorkerTest.cs
+++ b/csharp/WorkerTest/WorkerTest.cs
@@ -28,11 +28,11 @@ namespace WorkerTest
         private string sparkFilesDir = "";
         private int numberOfIncludesItems = 0;
         private int numBroadcastVariables = 0;
-        private byte[] command = SparkContext.BuildCommand(new CSharpWorkerFunc((pid, iter) => iter), SerializedMode.String, SerializedMode.String);
+        private readonly byte[] command = SparkContext.BuildCommand(new CSharpWorkerFunc((pid, iter) => iter), SerializedMode.String, SerializedMode.String);
 
         private TcpListener CreateServer(StringBuilder output, out Process worker)
         {
-            TcpListener tcpListener = new TcpListener(IPAddress.Parse("127.0.0.1"), 0);
+            TcpListener tcpListener = new TcpListener(IPAddress.Loopback, 0);
             tcpListener.Start();
             int port = (tcpListener.LocalEndpoint as IPEndPoint).Port;
 


### PR DESCRIPTION
- Use the pre-defined `IPAddress.Loopback` value that .NET provides, rather than magic constants.