### PR TITLE
Use Path.Combine to building worker exe path.

### DIFF
--- a/csharp/Samples/Microsoft.Spark.CSharp/MiscSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/MiscSamples.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Spark.CSharp.Samples
         [Sample]
         internal static void PiSample()
         {
-            const int slices = 2;
+            const int slices = 3;
             var n = (int) Math.Min(100000L*slices, int.MaxValue);
             var values = new List<int>(n);
             for (int i = 0; i <= n; i++)

--- a/csharp/WorkerTest/WorkerTest.cs
+++ b/csharp/WorkerTest/WorkerTest.cs
@@ -36,11 +36,18 @@ namespace WorkerTest
             tcpListener.Start();
             int port = (tcpListener.LocalEndpoint as IPEndPoint).Port;
 
-            worker = new Process();
-            worker.StartInfo.FileName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\CSharpWorker.exe";
-            worker.StartInfo.UseShellExecute = false;
-            worker.StartInfo.RedirectStandardInput = true;
-            worker.StartInfo.RedirectStandardOutput = true;
+            string exeLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".";
+
+            worker = new Process
+            {
+                StartInfo =
+                {
+                    FileName = Path.Combine(exeLocation, "CSharpWorker.exe"),
+                    UseShellExecute = false,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true
+                }
+            };
             worker.OutputDataReceived += new DataReceivedEventHandler((sender, e) =>
             {
                 if (!String.IsNullOrEmpty(e.Data))
@@ -49,6 +56,7 @@ namespace WorkerTest
                     output.AppendLine(e.Data);
                 }
             });
+            Console.WriteLine("Starting worker process from {0}", worker.StartInfo.FileName);
             worker.Start();
             worker.BeginOutputReadLine();
             worker.StandardInput.WriteLine(port);
@@ -180,7 +188,7 @@ namespace WorkerTest
                 s.Write(command, 0, command.Length / 2);
             }
 
-            AssertWorker(worker, output, -1, string.Format("System.ArgumentException: Incomplete bytes read: "));
+            AssertWorker(worker, output, -1, "System.ArgumentException: Incomplete bytes read: ");
 
             CSharpRDD_SocketServer.Stop();
         }


### PR DESCRIPTION
- Use Path.Combine for better cross-platform support for building the worker exe path, rather than hard coding the Windows specific backslash path separator.

- Assembly.Location can return null in some cases (particularly dynamic loading) so default to current directory "." in that case.

- Output the worker exe path being used, for easier debugging of tests not working.

- Use object initializer syntax for creating Process.StartInfo -- more compact and readable code.