### PR TITLE
Fix wrong method invoked issue in CSharpBackendHandler

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/SparkContextIpcProxy.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
             var pairwiseRdd = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.api.python.PairwiseRDD", rdd);
             var pairRddJvmReference = new JvmObjectReference(SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(pairwiseRdd, "asJavaPairRDD", new object[] { }).ToString());
 
-            var jpartitionerJavaReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.api.python.PythonPartitioner", new object[] { numPartitions, 0 });
+            var jpartitionerJavaReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("org.apache.spark.api.python.PythonPartitioner", new object[] { numPartitions, (long)0 });
             var partitionedPairRddJvmReference = new JvmObjectReference(SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(pairRddJvmReference, "partitionBy", new object[] { jpartitionerJavaReference }).ToString());
             var jvmRddReference = new JvmObjectReference(SparkCLRIpcProxy.JvmBridge.CallStaticJavaMethod("org.apache.spark.api.python.PythonRDD", "valueOfPair", new object[] { partitionedPairRddJvmReference }).ToString());
             //var jvmRddReference = new JvmObjectReference(SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(partitionedRddJvmReference, "rdd", new object[] { }).ToString());

--- a/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala
+++ b/scala/src/main/org/apache/spark/api/csharp/CSharpBackendHandler.scala
@@ -226,13 +226,18 @@ class CSharpBackendHandler(server: CSharpBackend) extends SimpleChannelInboundHa
       }
 
       if (!parameterWrapperType.isInstance(args(i))) {
-        //if (!parameterWrapperType.isAssignableFrom(args(i).getClass)) {
+        // non primitive types
         if (!parameterType.isPrimitive && args(i) != null) {
           return false
         }
-        //}
+
+        // primitive types
+        if (parameterType.isPrimitive && !parameterWrapperType.isInstance(args(i))) {
+          return false
+        }
       }
     }
+
     true
   }
 

--- a/scala/src/test/scala/org/apache/spark/api/csharp/CSharpBackendHandlerSuite.scala
+++ b/scala/src/test/scala/org/apache/spark/api/csharp/CSharpBackendHandlerSuite.scala
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package org.apache.spark.api.csharp
+
+import org.apache.spark.csharp.SparkCLRFunSuite
+import org.scalatest._
+
+class CSharpBackendHandlerSuite extends SparkCLRFunSuite with Matchers {
+  private val handler = new CSharpBackendHandler(null)
+
+  test("MethodMatch") {
+    class Methods {
+      def fill(value: Double, cols: Array[String]): Unit = {}
+
+      def fill(value: String, cols: Array[String]): Unit = {}
+    }
+
+    val params = Array[java.lang.Object]("unknown value", Array("col1", "col2"))
+    val matchedMethods = new Methods().getClass.getMethods.filter(m => m.getName.startsWith("fill"))
+      .filter(m => handler.matchMethod(params.length, params, m.getParameterTypes))
+
+    println("Matched methods:")
+    matchedMethods.foreach(println(_))
+    matchedMethods should have length (1)
+
+    val matchedMethodsStr = matchedMethods.map(m => m.toString).mkString(" ")
+    matchedMethodsStr should include(".fill(java.lang.String,java.lang.String[])")
+    matchedMethodsStr should not include(".fill(double,java.lang.String[])")
+  }
+
+  test("MethodMatchWithNumericParams") {
+    class Methods {
+      def fill(value: String, cols: Array[String]): Unit = {}
+
+      def fill(value: Long, cols: Array[String]): Unit = {}
+
+      def fill(value: Int, cols: Array[String]): Unit = {}
+    }
+
+    val value:Integer = 1
+    val params = Array[java.lang.Object](value, Array("col1", "col2"))
+    val matchedMethods = new Methods().getClass.getMethods.filter(m => m.getName.startsWith("fill"))
+      .filter(m => handler.matchMethod(params.length, params, m.getParameterTypes))
+
+    println("Matched methods:")
+    matchedMethods.foreach(println(_))
+    //matchedMethods should have length (2)
+    matchedMethods should have length (1)
+
+    val matchedMethodsStr = matchedMethods.map(m => m.toString).mkString(" ")
+
+    matchedMethodsStr should not include(".fill(java.lang.String,java.lang.String[])")
+    //matchedMethodsStr should include(".fill(long,java.lang.String[])")
+    matchedMethodsStr should include(".fill(int,java.lang.String[])")
+  }
+
+  test("ConstructorsMatch") {
+    // no match
+    var params = Array[java.lang.Object](new java.lang.Integer(1), new Integer(1))
+    var matchedConstructors = classOf[org.apache.spark.api.python.PythonPartitioner].getClass.
+      getConstructors.filter(c => handler.matchMethod(params.length, params, c.getParameterTypes))
+    matchedConstructors should have length (0)
+
+    // match 1
+    params = Array[java.lang.Object](new java.lang.Integer(1), new java.lang.Long(1))
+    matchedConstructors = classOf[org.apache.spark.api.python.PythonPartitioner].getConstructors
+      .filter(c => handler.matchMethod(params.length, params, c.getParameterTypes))
+
+    println("Matched constructors:")
+    matchedConstructors.foreach(println(_))
+    matchedConstructors should have length (1)
+    val matchedMethodsStr = matchedConstructors.map(m => m.toString).mkString(" ")
+    matchedMethodsStr should include("org.apache.spark.api.python.PythonPartitioner(int,long)")
+  }
+}


### PR DESCRIPTION
When run dataframe sample `DFNaFillSample` on Linux, below exception was thown:
```
argument type mismatch
java.lang.IllegalArgumentException: argument type mismatch
 at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 at java.lang.reflect.Method.invoke(Method.java:497)
 at org.apache.spark.api.csharp.CSharpBackendHandler.handleMethodCall(CSharpBackendHandler.scala:147)
 at org.apache.spark.api.csharp.CSharpBackendHandler.channelRead0(CSharpBackendHandler.scala:90)
 at org.apache.spark.api.csharp.CSharpBackendHandler.channelRead0(CSharpBackendHandler.scala:25)
 at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
 ...
```

The root cause is that for the given parameters which types are `String` and `String array`, method `DataFrameNaFunctions.fill(double,java.lang.String[])` was selected to execute, instead of `DataFrameNaFunctions.fill(java.lang.String,java.lang.String[])`.

Changes in this PR:

* Add type matching check for primitive types when select matched method in `CSharpBackendHandler`
* Change `SparkContextIpcProxy` to make the argument types could match the parameter types of `PythonPartitioner` constructor.
* Add unit tests