### PR TITLE
Add progress bar when download runtime dependencies for `RunSamples.cmd`

### DIFF
--- a/downloadtools.ps1
+++ b/downloadtools.ps1
@@ -74,7 +74,25 @@ function Download-File($url, $output)
     $start_time = Get-Date
     $wc = New-Object System.Net.WebClient
     Write-Output "[downloadtools.Download-File] Start downloading $url to $output ..."
-    $wc.DownloadFile($url, $output)
+    $Global:downloadComplete = $false
+    Register-ObjectEvent -InputObject $wc -EventName DownloadFileCompleted `
+        -SourceIdentifier Web.DownloadFileCompleted -Action {
+        $Global:downloadComplete = $True
+    }
+    Register-ObjectEvent -InputObject $wc  -EventName DownloadProgressChanged `
+        -SourceIdentifier Web.DownloadProgressChanged -Action {
+        $Global:Data = $event
+    }
+    $wc.DownloadFileAsync($url, $output)
+    While (-Not $isDownloaded) {
+        $percent = $Global:Data.SourceArgs.ProgressPercentage
+        $totalBytes = $Global:Data.SourceArgs.TotalBytesToReceive
+        $receivedBytes = $Global:Data.SourceArgs.BytesReceived
+        If ($percent -ne $null) {
+            Write-Progress -Activity ("Downloading file to {0} from {1}" -f $output,$url) -Status ("{0} bytes \ {1} bytes" -f $receivedBytes,$totalBytes)  -PercentComplete $percent
+        }
+    }
+    Write-Progress -Activity ("Downloading file to {0} from {1}" -f $output, $url) -Status ("{0} bytes \ {1} bytes" -f $receivedBytes,$totalBytes)  -Completed
     $duration = $(Get-Date).Subtract($start_time)
     if ($duration.Seconds -lt 2)
     {


### PR DESCRIPTION
When execute `RunSamples.cmd` for the first time on Windows, `RunSamples.cmd` will try to download all runtime dependencies. For dependencies like `spark-1.5.2-bin-hadoop2.6.tgz`, the file size is kind of large.

During downloading, for now user can't know how is the downloading going. Sometimes user might get confused as there is no response before downloading completes(especially when the internet connection is not good enough).

This PR adds progress bar when downloading files. 

![Preview](http://i.imgur.com/JsY37E9.jpg?1)


