### PR TITLE
Minor change to class `StructType` to make it easy to test

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Types.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Sql/Types.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Spark.CSharp.Sql
         internal StructType(IStructTypeProxy structTypeProxy)
         {
             this.structTypeProxy = structTypeProxy;
-            var jsonSchema = (structTypeProxy as StructTypeIpcProxy).ToJson();
+            var jsonSchema = structTypeProxy.ToJson();
             FromJson(jsonSchema);
         }
 


### PR DESCRIPTION
As interface `IStructTypeProxy` has already defined method `ToJson()`, so here no need to cast `structTypeProxy ` to class `StructTypeIpcProxy`. This change will make class `StructType` easy to test.