### PR TITLE
Use Runtime.getRuntime.halt() to stop JVM reliably if System.exit() c…

### DIFF
--- a/scala/src/main/org/apache/spark/deploy/csharp/CSharpRunner.scala
+++ b/scala/src/main/org/apache/spark/deploy/csharp/CSharpRunner.scala
@@ -103,7 +103,9 @@ object CSharpRunner {
           builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
           val process = builder.start()
 
-          new RedirectThread(process.getInputStream, System.out, "redirect CSharp output").start()
+          // Redirect stdout and stderr of C# process
+          new RedirectThread(process.getInputStream, System.out, "redirect CSharp stdout").start()
+          new RedirectThread(process.getErrorStream, System.out, "redirect CSharp stderr").start()
 
           returnCode = process.waitFor()
           closeBackend(csharpBackend)
@@ -112,20 +114,20 @@ object CSharpRunner {
         }
 
         println("[CSharpRunner.main] Return CSharpBackend code " + returnCode)
-        System.exit(returnCode)
+        CSharpSparkUtils.exit(returnCode)
       } else {
         println("***********************************************************************")
         println("* [CSharpRunner.main] Backend running debug mode. Press enter to exit *")
         println("***********************************************************************")
         Console.readLine()
         closeBackend(csharpBackend)
-        System.exit(0)
+        CSharpSparkUtils.exit(0)
       }
     } else {
       // scalastyle:off println
       println("[CSharpRunner.main] CSharpBackend did not initialize in " + backendTimeout + " seconds")
       // scalastyle:on println
-      System.exit(-1)
+      CSharpSparkUtils.exit(-1)
     }
   }
 

--- a/scala/src/main/org/apache/spark/launcher/SparkCLRSubmitArguments.scala
+++ b/scala/src/main/org/apache/spark/launcher/SparkCLRSubmitArguments.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.{ArrayBuffer, HashMap}
 object SparkCLRSubmitArguments {
 
   val csharpRunnerClass: String = "org.apache.spark.deploy.csharp.CSharpRunner"
-  var exitFn: Int => Unit = (exitCode: Int) => System.exit(exitCode)
+  var exitFn: Int => Unit = (exitCode: Int) => CSharpUtils.exit(exitCode)
   var printStream: PrintStream = System.err
 
   def main(args: Array[String]): Unit = {
@@ -73,7 +73,7 @@ class SparkCLRSubmitArguments(args: Seq[String], env: Map[String, String], exitF
   var options: Array[Array[String]] = null
 
   def this(args: Seq[String], env: Map[String, String]) {
-    this(args, env, (exitCode: Int) => System.exit(exitCode), System.err)
+    this(args, env, (exitCode: Int) => CSharpUtils.exit(exitCode), System.err)
   }
 
   private def printError(str: String): Unit = {


### PR DESCRIPTION
Use Runtime.getRuntime.halt() to stop JVM reliably if System.exit() can't exit timely