### PR TITLE
Fix null check issue in Broadcast & Add unit tests

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/SparkContext.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/SparkContext.cs
@@ -5,12 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
-using System.Threading.Tasks;
-using System.Net;
-using System.Net.Sockets;
 
 using Microsoft.Spark.CSharp.Interop;
 using Microsoft.Spark.CSharp.Proxy;
@@ -326,11 +322,6 @@ namespace Microsoft.Spark.CSharp.Core
         public RDD<byte[]> HadoopRDD(string inputFormatClass, string keyClass, string valueClass, string keyConverterClass = null, string valueConverterClass = null, IEnumerable<KeyValuePair<string, string>> conf = null)
         {
             return new RDD<byte[]>(SparkContextProxy.HadoopRDD(inputFormatClass, keyClass, valueClass, keyConverterClass, valueConverterClass, conf, 1), this, SerializedMode.None);
-        }
-
-        internal RDD<T> CheckpointFile<T>(string filePath, SerializedMode serializedMode)
-        {
-            return new RDD<T>(SparkContextProxy.CheckpointFile(filePath), this, serializedMode);
         }
 
         /// <summary>

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -64,6 +64,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="BroadcastTest.cs" />
     <Compile Include="DataFrameNaFunctionsTest.cs" />
     <Compile Include="DataFrameReaderTest.cs" />
     <Compile Include="DataFrameWriterTest.cs" />

--- a/csharp/AdapterTest/BroadcastTest.cs
+++ b/csharp/AdapterTest/BroadcastTest.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.Spark.CSharp.Core;
+using Microsoft.Spark.CSharp.Proxy;
+using NUnit.Framework;
+using Moq;
+
+namespace AdapterTest
+{
+    [TestFixture]
+    public class BroadcastTest
+    {
+        [Test]
+        public void TestBroadcastInDriver()
+        {
+            // mock broadcastProxy
+            var broadcastProxy = new Mock<IBroadcastProxy>();
+            broadcastProxy.Setup(m => m.Unpersist(It.IsAny<bool>()));
+
+            // mock sparkContextProxy
+            var sparkContextProxy = new Mock<ISparkContextProxy>();
+            long expectedBroacastId;
+            sparkContextProxy.Setup(m => m.ReadBroadcastFromFile(It.IsAny<string>(), out expectedBroacastId)).Returns(broadcastProxy.Object);
+
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, new SparkConf());
+            const int expectedValue = 1024;
+            Broadcast<int> broadcastVar = new Broadcast<int>(sc, expectedValue);
+
+            int value = broadcastVar.Value;
+            Assert.AreEqual(expectedValue, value);
+
+            // verify
+            sparkContextProxy.Verify(m => m.ReadBroadcastFromFile(It.IsAny<string>(), out expectedBroacastId), Times.Once);
+
+            // test unpersist
+            var filePath = broadcastVar.path;
+            Assert.IsNotNull(filePath);
+            Assert.IsTrue(File.Exists(filePath));
+
+            const bool blocking = true;
+            broadcastVar.Unpersist(blocking);
+
+            // verify
+            broadcastProxy.Verify(m => m.Unpersist(blocking), Times.Once);
+            Assert.IsFalse(File.Exists(filePath));
+        }
+
+        // create bytes for deserialization
+        internal Broadcast<T> CreateBroadcastVarInWorker<T>(T expectedValue, out long bid, out string path)
+        {
+            // create broadcast variable for serialization
+
+            // mock broadcastProxy
+            var broadcastProxy = new Mock<IBroadcastProxy>();
+            broadcastProxy.Setup(m => m.Unpersist(It.IsAny<bool>()));
+
+            // mock sparkContextProxy
+            var sparkContextProxy = new Mock<ISparkContextProxy>();
+            long expectedBroacastId;
+            sparkContextProxy.Setup(m => m.ReadBroadcastFromFile(It.IsAny<string>(), out expectedBroacastId)).Returns(broadcastProxy.Object);
+
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, new SparkConf());
+            Broadcast<T> broadcastVar = new Broadcast<T>(sc, expectedValue);
+
+            bid = broadcastVar.broadcastId;
+            path = broadcastVar.path;
+
+            var formatter = new BinaryFormatter();
+            var ms = new MemoryStream();
+            formatter.Serialize(ms, broadcastVar);
+
+            Broadcast<T> broadcastVarInWorker = (dynamic)formatter.Deserialize(new MemoryStream(ms.ToArray()));
+
+            return broadcastVarInWorker;
+        }
+
+        [Test]
+        public void TestBroadcastInWorker()
+        {
+            const int expectedValue = 1024;
+            long bid;
+            string dumpPath;
+
+            // worker side operations            
+            Broadcast<int> broadcastVarInWorker = CreateBroadcastVarInWorker(expectedValue, out bid, out dumpPath);
+            Broadcast.broadcastRegistry[bid] = new Broadcast(dumpPath);
+
+            var broadcastValueInWorker = broadcastVarInWorker.Value;
+
+            // assert
+            Assert.IsNotNull(broadcastVarInWorker);
+            Assert.AreEqual(expectedValue, broadcastValueInWorker);
+
+            // test unpersist operation in worker
+            Assert.Throws<ArgumentException>(() => broadcastVarInWorker.Unpersist());
+        }
+
+        [Test]
+        public void TestOperationOnDestroyedBroadcastInWorker()
+        {
+            const int expectedValue = 2048;
+            long bid;
+            string dumpPath;
+
+            // worker side operations            
+            Broadcast<int> broadcastVarInWorker = CreateBroadcastVarInWorker(expectedValue, out bid, out dumpPath);
+            Broadcast.broadcastRegistry.Remove(bid);
+
+            // assert
+            Assert.Throws<ArgumentException>(() => { var broadcastValueInWorker = broadcastVarInWorker.Value; });
+        }
+    }
+}

--- a/csharp/AdapterTest/SparkContextTest.cs
+++ b/csharp/AdapterTest/SparkContextTest.cs
@@ -6,9 +6,11 @@ using System.Text;
 using System.Collections.Generic;
 using AdapterTest.Mocks;
 using Microsoft.Spark.CSharp.Core;
+using Microsoft.Spark.CSharp.Interop;
 using Microsoft.Spark.CSharp.Interop.Ipc;
 using Microsoft.Spark.CSharp.Proxy;
 using Microsoft.Spark.CSharp.Proxy.Ipc;
+using Moq;
 using NUnit.Framework;
 
 namespace AdapterTest
@@ -60,6 +62,511 @@ namespace AdapterTest
             var paramValuesToTextFileMethod = (rdd.RddProxy as MockRddProxy).mockRddReference as object[];
             Assert.AreEqual(@"c:\path\to\rddinput.txt", paramValuesToTextFileMethod[0]);
             Assert.AreEqual(8, paramValuesToTextFileMethod[1]);
+        }
+
+        [Test]
+        public void TestSparkContextVersionProperty()
+        {
+            const string expectedVersion = "1.5.2";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.Version).Returns(expectedVersion);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            string version = sc.Version;
+
+            // assert
+            Assert.IsNotNull(version);
+            Assert.AreEqual(expectedVersion, version);
+        }
+
+        [Test]
+        public void TestSparkContextStartTimeProperty()
+        {
+            long expectedStartTime = DateTime.Now.Millisecond;
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.StartTime).Returns(expectedStartTime);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            long startTime = sc.StartTime;
+
+            // assert
+            Assert.AreEqual(expectedStartTime, startTime);
+        }
+
+        [Test]
+        public void TestSparkContextDefaultMinPartitionsProperty()
+        {
+            const int expectedDefaultMinPartitions = 5;
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.DefaultMinPartitions).Returns(expectedDefaultMinPartitions);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            int defaultMinPartitions = sc.DefaultMinPartitions;
+
+            // assert
+            Assert.AreEqual(expectedDefaultMinPartitions, defaultMinPartitions);
+        }
+
+        [Test]
+        public void TestSparkContextSparkUserProperty()
+        {
+            const string expectedUser = "SPARKCLR_USER";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.SparkUser).Returns(expectedUser);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            string user = sc.SparkUser;
+
+            // assert
+            Assert.IsNotNull(user);
+            Assert.AreEqual(expectedUser, user);
+        }
+
+        [Test]
+        public void TestSparkContextStatusTrackerProperty()
+        {
+            Mock<IStatusTrackerProxy> statusTrackerProxy = new Mock<IStatusTrackerProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.StatusTracker).Returns(statusTrackerProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            var statusTracker = sc.StatusTracker;
+
+            // assert
+            Assert.IsNotNull(statusTracker);
+        }
+
+        [Test]
+        public void TestCancelAllJobs()
+        {
+            // Arrange
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.CancelAllJobs());
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            sc.CancelAllJobs();
+
+            // Assert
+            sparkContextProxy.Verify(m => m.CancelAllJobs(), Times.Once);
+        }
+
+        [Test]
+        public void TestCancelJobGroup()
+        {
+            // Arrange
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.CancelJobGroup(It.IsAny<string>()));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            const string groupId = "group-0";
+            sc.CancelJobGroup(groupId);
+
+            // Assert
+            sparkContextProxy.Verify(m => m.CancelJobGroup(groupId), Times.Once);
+        }
+
+        [Test]
+        public void TestSetLogLevel()
+        {
+            // Arrange
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.SetLogLevel(It.IsAny<string>()));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            const string logLevel = "INFO";
+            sc.SetLogLevel(logLevel);
+
+            // Assert
+            sparkContextProxy.Verify(m => m.SetLogLevel(logLevel), Times.Once);
+        }
+
+        [Test]
+        public void TestGetLocalProperty()
+        {
+            // Arrange
+            const string key = "spark.local.dir";
+            const string expectedValue = @"D:\tmp\";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.GetLocalProperty(It.IsAny<string>())).Returns(expectedValue);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            var value = sc.GetLocalProperty(key);
+
+            // Assert
+            Assert.IsNotNull(value);
+            Assert.AreEqual(expectedValue, value);
+        }
+
+        [Test]
+        public void TestSetLocalProperty()
+        {
+            // Arrange
+            const string key = "spark.local.dir";
+            const string value = @"D:\tmp\";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.SetLocalProperty(It.IsAny<string>(), It.IsAny<string>()));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            sc.SetLocalProperty(key, value);
+
+            // Assert
+            sparkContextProxy.Verify(m => m.SetLocalProperty(key, value), Times.Once);
+        }
+
+        [Test]
+        public void TestSetJobGroup()
+        {
+            // Arrange
+            const string groupId = "group-1";
+            const string description = "group 1 description";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.SetJobGroup(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            sc.SetJobGroup(groupId, description);
+
+            // Assert
+            sparkContextProxy.Verify(m => m.SetJobGroup(groupId, description, false), Times.Once);
+        }
+
+        [Test]
+        public void TestSetCheckpointDir()
+        {
+            // Arrange
+            const string directory = @"D:\tmp";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.SetCheckpointDir(It.IsAny<string>()));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            sc.SetCheckpointDir(directory);
+
+            // Assert
+            sparkContextProxy.Verify(m => m.SetCheckpointDir(directory), Times.Once);
+        }
+
+        [Test]
+        public void TestAddFile()
+        {
+            // Arrange
+            const string path = @"D:\tmp";
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.AddFile(It.IsAny<string>()));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            sc.AddFile(path);
+
+            // Assert
+            sparkContextProxy.Verify(m => m.AddFile(path), Times.Once);
+        }
+
+        [Test]
+        public void TestBroadcast()
+        {
+            // Arrange
+            long broadcastId = 100L;
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.ReadBroadcastFromFile(It.IsAny<string>(), out broadcastId));
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+            const string expectedValue = "broadcastvar1";
+
+            // Act
+            var broadcastVar = sc.Broadcast(expectedValue);
+
+            // Assert
+            Assert.IsNotNull(broadcastVar);
+            Assert.AreEqual(expectedValue, broadcastVar.Value);
+            Assert.AreEqual(broadcastId, broadcastVar.broadcastId);
+
+            sparkContextProxy.Verify(m => m.ReadBroadcastFromFile(It.IsAny<string>(), out broadcastId), Times.Once);
+        }
+
+        [Test]
+        public void TestParallelize()
+        {
+            // Arrange
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.Parallelize(It.IsAny<IEnumerable<byte[]>>(), It.IsAny<int>())).Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            var nums = new[] { 0, 2, 3, 4, 6 };
+            RDD<int> rdd = sc.Parallelize(nums, -2);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+        }
+
+        [Test]
+        public void TestEmptyRDD()
+        {
+            // Arrange
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.EmptyRDD()).Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            RDD<int> rdd = sc.EmptyRDD<int>();
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.None, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestWholeTextFiles()
+        {
+            // Arrange
+            const string filePath = @"d:\data";
+            const int minPartitions = 10;
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.WholeTextFiles(filePath, minPartitions)).Returns(rddProxy.Object);
+            sparkContextProxy.Setup(m => m.DefaultMinPartitions).Returns(minPartitions);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            RDD<KeyValuePair<byte[], byte[]>> rdd = sc.WholeTextFiles(filePath, null);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.Pair, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestBinaryFiles()
+        {
+            // Arrange
+            const string filePath = @"d:\data";
+            const int minPartitions = 10;
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.BinaryFiles(filePath, minPartitions)).Returns(rddProxy.Object);
+            sparkContextProxy.Setup(m => m.DefaultMinPartitions).Returns(minPartitions);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            RDD<KeyValuePair<byte[], byte[]>> rdd = sc.BinaryFiles(filePath, null);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.Pair, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestSequenceFiles()
+        {
+            // Arrange
+            const string filePath = @"hdfs://path/to/files";
+
+            const int defaultParallelism = 10;
+            const string keyClass = "java.lang.Long";
+            const string valueClass = "java.lang.String";
+            const string keyConverterClass = "xyz.KeyConveter";
+            const string valueConverterClass = "xyz.valueConveter";
+
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.SequenceFile(filePath, keyClass, valueClass, keyConverterClass, valueConverterClass, It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(rddProxy.Object);
+            sparkContextProxy.Setup(m => m.DefaultParallelism).Returns(defaultParallelism);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            // Act
+            RDD<byte[]> rdd = sc.SequenceFile(filePath, keyClass, valueClass, keyConverterClass, valueConverterClass, null);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.None, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestNewAPIHadoopFile()
+        {
+            // Arrange
+            const string filePath = @"hdfs://path/to/files";
+
+            const string keyClass = "java.lang.Long";
+            const string valueClass = "java.lang.String";
+            const string keyConverterClass = "xyz.KeyConveter";
+            const string valueConverterClass = "xyz.valueConveter";
+
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.NewAPIHadoopFile(filePath, It.IsAny<string>(), keyClass, valueClass, keyConverterClass, valueConverterClass, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<int>()))
+                .Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            const string inputFormatClass = "org.apache.hadoop.mapreduce.lib.input.TextInputFormat";
+            // Act
+            RDD<byte[]> rdd = sc.NewAPIHadoopFile(filePath, inputFormatClass, keyClass, valueClass, keyConverterClass, valueConverterClass);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.None, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestHadoopFile()
+        {
+            // Arrange
+            const string filePath = @"hdfs://path/to/files";
+
+            const string keyClass = "java.lang.Long";
+            const string valueClass = "java.lang.String";
+            const string keyConverterClass = "xyz.KeyConveter";
+            const string valueConverterClass = "xyz.valueConveter";
+
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.HadoopFile(filePath, It.IsAny<string>(), keyClass, valueClass, keyConverterClass, valueConverterClass, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<int>()))
+                .Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            const string inputFormatClass = "org.apache.hadoop.mapreduce.lib.input.TextInputFormat";
+            // Act
+            RDD<byte[]> rdd = sc.HadoopFile(filePath, inputFormatClass, keyClass, valueClass, keyConverterClass, valueConverterClass);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.None, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestNewAPIHadoopRDD()
+        {
+            // Arrange
+            const string keyClass = "java.lang.Long";
+            const string valueClass = "java.lang.String";
+            const string keyConverterClass = "xyz.KeyConveter";
+            const string valueConverterClass = "xyz.valueConveter";
+
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.NewAPIHadoopRDD(It.IsAny<string>(), keyClass, valueClass, keyConverterClass, valueConverterClass, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<int>()))
+                .Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            const string inputFormatClass = "org.apache.hadoop.mapreduce.lib.input.TextInputFormat";
+            var conf = new KeyValuePair<string, string>[] { };
+            // Act
+            RDD<byte[]> rdd = sc.NewAPIHadoopRDD(inputFormatClass, keyClass, valueClass, keyConverterClass, valueConverterClass, conf);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.None, rdd.serializedMode);
+        }
+
+        [Test]
+        public void TestHadoopRDD()
+        {
+            // Arrange
+            const string keyClass = "java.lang.Long";
+            const string valueClass = "java.lang.String";
+            const string keyConverterClass = "xyz.KeyConveter";
+            const string valueConverterClass = "xyz.valueConveter";
+
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.HadoopRDD(It.IsAny<string>(), keyClass, valueClass, keyConverterClass, valueConverterClass, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<int>()))
+                .Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            const string inputFormatClass = "org.apache.hadoop.mapreduce.lib.input.TextInputFormat";
+            var conf = new KeyValuePair<string, string>[] { };
+            // Act
+            RDD<byte[]> rdd = sc.HadoopRDD(inputFormatClass, keyClass, valueClass, keyConverterClass, valueConverterClass, conf);
+
+            // Assert
+            Assert.IsNotNull(rdd);
+            Assert.AreEqual(rddProxy.Object, rdd.RddProxy);
+            Assert.AreEqual(sc, rdd.sparkContext);
+            Assert.AreEqual(SerializedMode.None, rdd.serializedMode);
+        }
+
+        public RDD<T> TestUnion<T>(IEnumerable<RDD<T>> rdds)
+        {
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.EmptyRDD()).Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+            RDD<T> result = sc.Union<T>(rdds);
+
+            Assert.IsNotNull(result);
+            sparkContextProxy.Verify(m => m.EmptyRDD(), Times.Once);
+            return result;
+        }
+
+        [Test]
+        public void TestUnionWhenRddsIsNull()
+        {
+            TestUnion<string>(null);
+        }
+
+        [Test]
+        public void TestUnionWhenRddsIsEmpty()
+        {
+            TestUnion<string>(new RDD<string>[] { });
+        }
+
+        [Test]
+        public void TestUnionWhenRddsHaveOnlyOneElement()
+        {
+            var rdds = new RDD<int>[] { new RDD<int>() };
+
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            RDD<int> result = sc.Union<int>(rdds);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(rdds[0], result);
+        }
+
+        [Test]
+        public void TestUnion()
+        {
+            var rdds = new RDD<string>[]
+            {
+                new RDD<string>(new Mock<IRDDProxy>().Object, null, SerializedMode.String),
+                new RDD<string>(new Mock<IRDDProxy>().Object, null, SerializedMode.String)
+            };
+
+            Mock<IRDDProxy> rddProxy = new Mock<IRDDProxy>();
+            Mock<ISparkContextProxy> sparkContextProxy = new Mock<ISparkContextProxy>();
+            sparkContextProxy.Setup(m => m.Union(It.IsAny<IEnumerable<IRDDProxy>>())).Returns(rddProxy.Object);
+            SparkContext sc = new SparkContext(sparkContextProxy.Object, null);
+
+            RDD<string> result = sc.Union<string>(rdds);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(rdds[0].serializedMode, result.serializedMode);
+            Assert.AreEqual(rddProxy.Object, result.RddProxy);
         }
     }
 }


### PR DESCRIPTION
* Fix null check failure issue when `T` is a primitive type in `Broadcast.cs`
* Remove unused method `internal CheckpointFile<T>(string filePath, SerializedMode serializedMode)` in `SparkContext.cs`
*  Add unit tests to improve test coverage of `Broadcast` and `SparkContext`