### PR TITLE
Remove unused methods in RDD & Improve test coverage in 'Core' namespace.

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Core/RDD.cs
@@ -4,17 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Reflection;
-using System.IO;
-using System.Net.Sockets;
 using Microsoft.Spark.CSharp.Proxy;
-using Microsoft.Spark.CSharp.Interop.Ipc;
-using Microsoft.Spark.CSharp.Sql;
-using Razorvine.Pickle;
-using Razorvine.Pickle.Objects;
 
 namespace Microsoft.Spark.CSharp.Core
 {
@@ -77,14 +67,6 @@ namespace Microsoft.Spark.CSharp.Core
             get
             {
                 return RddProxy.Name;
-            }
-        }
-
-        internal int DefaultReducePartitions
-        {
-            get
-            {
-                return GetNumPartitions();
             }
         }
 

--- a/csharp/AdapterTest/AdapterTest.csproj
+++ b/csharp/AdapterTest/AdapterTest.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Mocks\MockRDDCollector.cs" />
     <Compile Include="Mocks\MockRow.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StatusTrackerTest.cs" />
     <Compile Include="TestWithMoqDemo.cs" />
     <Compile Include="Mocks\MockStructTypeProxy.cs" />
     <Compile Include="DStreamTest.cs" />

--- a/csharp/AdapterTest/Mocks/MockRddProxy.cs
+++ b/csharp/AdapterTest/Mocks/MockRddProxy.cs
@@ -22,7 +22,7 @@ namespace AdapterTest.Mocks
     {
         internal IEnumerable<dynamic> result;
         internal bool pickle;
-
+        internal string name;
         internal object[] mockRddReference;
 
         public IRDDCollector RDDCollector
@@ -93,7 +93,7 @@ namespace AdapterTest.Mocks
 
         public int GetNumPartitions()
         {
-            return 1;
+            return 2;
         }
 
         public IRDDProxy Sample(bool withReplacement, double fraction, long seed)
@@ -128,11 +128,13 @@ namespace AdapterTest.Mocks
 
         public string Name
         {
-            get { return null; }
+            get { return name; }
         }
 
         public void SetName(string name)
-        {}
+        {
+            this.name = name;
+        }
 
         public IRDDProxy Coalesce(int numPartitions, bool shuffle)
         {
@@ -179,7 +181,7 @@ namespace AdapterTest.Mocks
 
         public StorageLevel GetStorageLevel()
         {
-            return null;
+            return StorageLevel.storageLevel[StorageLevelType.MEMORY_ONLY];
         }
     }
 }

--- a/csharp/AdapterTest/PairRDDTest.cs
+++ b/csharp/AdapterTest/PairRDDTest.cs
@@ -27,7 +27,8 @@ namespace AdapterTest
         {
             foreach (var record in pairs.CountByKey())
             {
-                Assert.AreEqual(record.Value, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                // the 1st paramter of AreEqual() method is the expected value, the 2nd one is the acutal value.
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value);
             }
         }
 
@@ -36,21 +37,53 @@ namespace AdapterTest
         {
             foreach (var record in pairs.GroupWith(pairs).Collect())
             {
-                Assert.AreEqual(record.Value.Item1.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
-                Assert.AreEqual(record.Value.Item2.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item1.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item2.Count);
             }
             foreach (var record in pairs.GroupWith(pairs, pairs).Collect())
             {
-                Assert.AreEqual(record.Value.Item1.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
-                Assert.AreEqual(record.Value.Item2.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
-                Assert.AreEqual(record.Value.Item3.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item1.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item2.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item3.Count);
             }
             foreach (var record in pairs.GroupWith(pairs, pairs, pairs).Collect())
             {
-                Assert.AreEqual(record.Value.Item1.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
-                Assert.AreEqual(record.Value.Item2.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
-                Assert.AreEqual(record.Value.Item3.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
-                Assert.AreEqual(record.Value.Item4.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item1.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item2.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item3.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item4.Count);
+            }
+        }
+
+        /// <summary>
+        /// Test RDD.GroupWith() method with different KeyValuePair<K,V> types.
+        /// </summary>
+        [Test]
+        public void TestPairRddGroupWith2()
+        {
+            var pairs1 = pairs.Map(p => new KeyValuePair<string, double>(p.Key, Convert.ToDouble(p.Value)));
+            var pairs2 = pairs.Map(p => new KeyValuePair<string, string>(p.Key, p.Value.ToString()));
+            var pairs3 = pairs.Map(p => new KeyValuePair<string, long>(p.Key, Convert.ToInt64(p.Value)));
+
+            foreach (var record in pairs.GroupWith(pairs1).Collect())
+            {
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item1.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item2.Count);
+            }
+
+            foreach (var record in pairs.GroupWith(pairs1, pairs2).Collect())
+            {
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item1.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item2.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item3.Count);
+            }
+
+            foreach (var record in pairs.GroupWith(pairs1, pairs2, pairs3).Collect())
+            {
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item1.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item2.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item3.Count);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Item4.Count);
             }
         }
 
@@ -59,9 +92,9 @@ namespace AdapterTest
         {
             var reduce = pairs.ReduceByKey((x, y) => x + y);
             var records = reduce.SubtractByKey(reduce.Filter(kvp => kvp.Key != "The")).Collect();
-            Assert.AreEqual(records.Length, 1);
-            Assert.AreEqual(records[0].Key, "The");
-            Assert.AreEqual(records[0].Value, 23);
+            Assert.AreEqual(1, records.Length);
+            Assert.AreEqual("The", records[0].Key);
+            Assert.AreEqual(23, records[0].Value);
         }
 
         [Test]
@@ -69,7 +102,7 @@ namespace AdapterTest
         {
             foreach (var record in pairs.ReduceByKeyLocally((x, y) => x + y))
             {
-                Assert.AreEqual(record.Value, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value);
             }
         }
 
@@ -78,7 +111,7 @@ namespace AdapterTest
         {
             foreach (var record in pairs.FoldByKey(() => 0, (x, y) => x + y).Collect())
             {
-                Assert.AreEqual(record.Value, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value);
             }
         }
 
@@ -87,7 +120,7 @@ namespace AdapterTest
         {
             foreach (var record in pairs.AggregateByKey(() => 0, (x, y) => x + y, (x, y) => x + y).Collect())
             {
-                Assert.AreEqual(record.Value, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value);
             }
         }
 
@@ -96,7 +129,7 @@ namespace AdapterTest
         {
             foreach (var record in pairs.GroupByKey().Collect())
             {
-                Assert.AreEqual(record.Value.Count, record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22);
+                Assert.AreEqual(record.Key == "The" || record.Key == "dog" || record.Key == "lazy" ? 23 : 22, record.Value.Count);
             }
         }
 
@@ -104,22 +137,22 @@ namespace AdapterTest
         public void TestPairRddLookup()
         {
             var records = pairs.ReduceByKey((x, y) => x + y).Lookup("The");
-            Assert.AreEqual(records.Length, 1);
-            Assert.AreEqual(records[0], 23);
+            Assert.AreEqual(1, records.Length);
+            Assert.AreEqual(23, records[0]);
         }
 
         [Test]
         public void TestPairRddKeys()
         {
             var records = pairs.ReduceByKey((x, y) => x + y).Keys().Collect();
-            Assert.AreEqual(records.Length, 9);
+            Assert.AreEqual(9, records.Length);
         }
 
         [Test]
         public void TestPairRddValues()
         {
             var records = pairs.ReduceByKey((x, y) => x + y).Values().Collect();
-            Assert.AreEqual(records.Length, 9);
+            Assert.AreEqual(9, records.Length);
         }
 
         [Test]

--- a/csharp/AdapterTest/StatusTrackerTest.cs
+++ b/csharp/AdapterTest/StatusTrackerTest.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AdapterTest.Mocks;
+using Microsoft.Spark.CSharp.Core;
+using Microsoft.Spark.CSharp.Interop;
+using Microsoft.Spark.CSharp.Sql;
+using Microsoft.Spark.CSharp.Proxy;
+using NUnit.Framework;
+using Moq;
+
+namespace AdapterTest
+{
+    /// <summary>
+    /// Validates interaction between StatusTracker and its proxies
+    /// </summary>
+    [TestFixture]
+    public class StatusTrackerTest
+    {
+        /// <summary>
+        /// Test 'GetJobIdsForGroup', 'GetActiveJobsIds' and 'GetActiveStageIds' methods.
+        /// </summary>
+        [Test]
+        public void TestStatusTrackerMethods()
+        {
+            // arrange
+            Mock<IStatusTrackerProxy> statusTrackerProxy = new Mock<IStatusTrackerProxy>();
+
+            // GetJobIdsForGroup
+            const string jobGroup = "group-0";
+            int[] expectedJobIds = new[] { 1001, 1002, 1003 };
+            statusTrackerProxy.Setup(m => m.GetJobIdsForGroup(It.IsAny<string>())).Returns(expectedJobIds);
+
+            // GetActiveJobsIds
+            int[] expectedActiveJobIds = new[] { 1001, 1003 };
+            statusTrackerProxy.Setup(m => m.GetActiveJobsIds()).Returns(expectedActiveJobIds);
+
+            // GetActiveStageIds
+            int[] expectedActiveStageIds = new[] { 666, 667, 668 };
+            statusTrackerProxy.Setup(m => m.GetActiveStageIds()).Returns(expectedActiveStageIds);
+
+            var tracker = new StatusTracker(statusTrackerProxy.Object);
+
+            // act
+            var jobIds = tracker.GetJobIdsForGroup(jobGroup);
+            var activeJobIds = tracker.GetActiveJobsIds();
+            var activeStageIds = tracker.GetActiveStageIds();
+
+            // assert
+            // GetJobIdsForGroup
+            Assert.IsNotNull(jobIds);
+            Assert.AreEqual(expectedJobIds, jobIds);
+
+            // GetActiveJobsIds
+            Assert.IsNotNull(activeJobIds);
+            Assert.AreEqual(expectedActiveJobIds, activeJobIds);
+
+            // GetActiveStageIds
+            Assert.IsNotNull(activeStageIds);
+            Assert.AreEqual(expectedActiveStageIds, activeStageIds);
+        }
+
+        /// <summary>
+        /// Test StatusTracker.GetJobInfo() and methods of class SparkJobInfo.
+        /// </summary>
+        [Test]
+        public void TestSparkJobInfo()
+        {
+            const int jobId = 65536;
+            int[] stageIds = new[] { 100, 102, 104 };
+            const string status = "RUNNING";
+
+            // arrange
+            Mock<IStatusTrackerProxy> statusTrackerProxy = new Mock<IStatusTrackerProxy>();
+            var expectedJobInfo = new SparkJobInfo(jobId, stageIds, status);
+            statusTrackerProxy.Setup(m => m.GetJobInfo(It.IsAny<int>())).Returns(expectedJobInfo);
+            var tracker = new StatusTracker(statusTrackerProxy.Object);
+
+            // act
+            SparkJobInfo jobInfo = tracker.GetJobInfo(jobId);
+
+            // assert
+            Assert.IsNotNull(jobInfo);
+            Assert.AreEqual(jobId, jobInfo.JobId);
+            Assert.AreEqual(stageIds, jobInfo.StageIds);
+            Assert.AreEqual(status, jobInfo.Status);
+        }
+
+        /// <summary>
+        /// Test StatusTracker.GetStageInfo() and methods of class SparkStageInfo.
+        /// </summary>
+        [Test]
+        public void TestSparkStageInfo()
+        {
+            const int stageId = 65536;
+            const int currentAttemptId = 1;
+            long submissionTime = DateTime.Now.Millisecond;
+            const string name = "name-1";
+            const int numTasks = 20;
+            const int numActiveTasks = 10;
+            const int numCompletedTasks = 5;
+            const int numFailedTasks = 0;
+
+            // arrange
+            Mock<IStatusTrackerProxy> statusTrackerProxy = new Mock<IStatusTrackerProxy>();
+            var expectedStageInfo = new SparkStageInfo(stageId, currentAttemptId, submissionTime, name, numTasks, numActiveTasks, numCompletedTasks, numFailedTasks);
+            statusTrackerProxy.Setup(m => m.GetStageInfo(It.IsAny<int>())).Returns(expectedStageInfo);
+            var tracker = new StatusTracker(statusTrackerProxy.Object);
+
+            // act
+            SparkStageInfo stageInfo = tracker.GetStageInfo(stageId);
+
+            // assert
+            Assert.IsNotNull(stageInfo);
+            Assert.AreEqual(stageId, stageInfo.StageId);
+            Assert.AreEqual(currentAttemptId, stageInfo.CurrentAttemptId);
+            Assert.AreEqual(submissionTime, stageInfo.SubmissionTime);
+            Assert.AreEqual(name, stageInfo.Name);
+            Assert.AreEqual(numTasks, stageInfo.NumTasks);
+            Assert.AreEqual(numActiveTasks, stageInfo.NumActiveTasks);
+            Assert.AreEqual(numCompletedTasks, stageInfo.NumCompletedTasks);
+            Assert.AreEqual(numFailedTasks, stageInfo.NumFailedTasks);
+        }
+    }
+}


### PR DESCRIPTION
* Remove unused method `internal int DefaultReducePartitions` in `RDD`
* Improve test coverage of `PairRDDFunctions`
* Improve test coverage of `RDD`
* Improve test coverage of `StatusTracker`