### PR TITLE
Let the C# process exit if it processes CallBackRequest fail

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StreamingContextIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/StreamingContextIpcProxy.cs
@@ -267,6 +267,11 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
                             if (!callbackSocketShutdown)
                             {
                                 logger.LogException(e);
+
+                                // exit when exception happens
+                                logger.LogError("ProcessCallbackRequest fail, will exit ...");
+                                Thread.Sleep(1000);
+                                System.Environment.Exit(1);
                             }
                         }
                     }


### PR DESCRIPTION
1. Let the C# process exit if it processes CallBackRequest fail
2. Refactor the accumulator test, add test cases