### PR TITLE
RunSamples.cmd should signal failure if non-zero RC from sparkclr-submit script

### DIFF
--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -1,6 +1,10 @@
 @echo OFF
 setlocal enabledelayedexpansion
 
+SET CMDHOME=%~dp0
+@REM Remove trailing backslash \
+set CMDHOME=%CMDHOME:~0,-1%
+
 set VERBOSE=
 set USER_EXE=
 
@@ -31,9 +35,13 @@ if "%1" == "" (
     goto argsloop
 )
 
+pushd "%CMDHOME%"
+@echo [RunSamples.cmd] CWD=
+@cd
+
 @rem check prerequisites
 call precheck.cmd
-if %precheck% == "bad" (goto :eof)
+if "%precheck%" == "bad" (goto :EOF)
 
 @rem 
 @rem setup Hadoop and Spark versions
@@ -72,7 +80,9 @@ set SAMPLES_DIR=%SPARKCLR_HOME%\samples
 @echo [RunSamples.cmd] SPARKCLR_HOME=%SPARKCLR_HOME%
 @echo [RunSamples.cmd] SPARKCSV_JARS=%SPARKCSV_JARS%
 
-pushd %SPARKCLR_HOME%\scripts
+pushd "%SPARKCLR_HOME%\scripts"
+@echo [RunSamples.cmd] CWD=
+@cd
 
 if "!USER_EXE!"=="" (
     @echo [RunSamples.cmd] call sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data %*
@@ -82,4 +92,13 @@ if "!USER_EXE!"=="" (
     call sparkclr-submit.cmd %*
 )
 
-popd
+@if ERRORLEVEL 1 GOTO :ErrorStop
+
+@GOTO :EOF
+
+:ErrorStop
+set RC=%ERRORLEVEL%
+@echo ===== sparkclr-submit FAILED error %RC% =====
+exit /B %RC%
+
+:EOF

--- a/build/localmode/precheck.cmd
+++ b/build/localmode/precheck.cmd
@@ -1,6 +1,6 @@
 @echo OFF
 
-set precheck="ok"
+set precheck=ok
 
 if not exist "%JAVA_HOME%\bin\java.exe" (
     @echo. 
@@ -12,13 +12,13 @@ if not exist "%JAVA_HOME%\bin\java.exe" (
     @echo. 
     @echo ============================================================================================
     @echo. 
-    set precheck="bad"
+    set precheck=bad
     goto :eof
 )
 
 set path=%path%;%JAVA_HOME%\bin
 
-set version="unknown"
+set version=unknown
 if "%VisualStudioVersion%" == "" ( goto vstudiowarning)
 
 @REM VS 2013 == Version 12; VS 2015 == Version 14


### PR DESCRIPTION
This tweak to `RunSamples.cmd` script makes it easier to detect any problems in the build environment, because build agent [eg VSO] will detect non-zero exit code which was previously being masked by extra commands at end of script.

- `RunSamples.cmd` should signal runtime failure if non-zero RC from underlying call to `sparkclr-submit.cmd` script. [The final `popd` was previously masking this value.]

- Fix non-standard usage of quotes between RunSamples.cmd and PreCheck.cmd scripts.

- Print directory location info for strategic pushd's

Should have no affect on the core team's Appveyor build, but my private VSO build was not detecting / marking build failures when it should have been due to some test config issues.