### PR TITLE
Fix the issue in convering properties with jdbc implementation

### DIFF
--- a/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/DataFrameWriterIpcProxy.cs
+++ b/csharp/Adapter/Microsoft.Spark.CSharp/Proxy/Ipc/DataFrameWriterIpcProxy.cs
@@ -61,8 +61,18 @@ namespace Microsoft.Spark.CSharp.Proxy.Ipc
 
         public void Jdbc(string url, string table, Dictionary<string, string> properties)
         {
+            var propertiesJvmReference = SparkCLRIpcProxy.JvmBridge.CallConstructor("java.util.Properties", new object[] { });
+            if (properties != null)
+            {
+                foreach (var property in properties)
+                {
+                    SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(propertiesJvmReference, "setProperty",
+                        new object[] { property.Key, property.Value });
+                }
+            }
+
             SparkCLRIpcProxy.JvmBridge.CallNonStaticJavaMethod(
-                jvmDataFrameWriterReference, "jdbc", new object[] { url, table, properties });
+                jvmDataFrameWriterReference, "jdbc", new object[] { url, table, propertiesJvmReference });
         }
     }
 }


### PR DESCRIPTION
For `DataFrameWriter.jdbc(url: String, table: String, connectionProperties: Properties)`, the third parameter is required to be a `java.util.Properties` type object. Here explicitly create a `java.util.Properties` object in jvm with the given c# `Dictionary` object `properties`.