### PR TITLE
M2 build settings and mvn --quiet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,8 @@
 **/target/
 **/.idea/
 scala/dependency-reduced-pom.xml
-run/
-tools/
+build/runtime/
+build/tools/
 *.log
 lib/
 
@@ -38,6 +38,7 @@ lib/
 SparkCLRCodeCoverage.xml
 AdapterTestCoverage.xml
 TestResult.xml
+csharp/SparkCLR.compiled.nuspec
 
 # Office Doc Temp files #
 #########################

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ build_script:
   - cmd: echo appveyor environment BUILD_NUMBER=[%APPVEYOR_BUILD_NUMBER%] BUILD_VERSION=[%APPVEYOR_BUILD_VERSION%] REPO_TAG=[%APPVEYOR_REPO_TAG%] REPO_TAG_NAME=[%APPVEYOR_REPO_TAG_NAME%] APPVEYOR=[%APPVEYOR%] CI=[%CI%]
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET MVN_QUIET=--quiet
   - cmd: cd .\build
   - cmd: .\Build.cmd
   - cmd: cd ..

--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -88,6 +88,8 @@ if %ERRORLEVEL% NEQ 0 (
 
 @echo SparkCLR Scala binaries
 copy /y target\*.jar "%SPARKCLR_HOME%\lib\"
+@REM Exclude any original pre-shaded .jar files
+del /q "%SPARKCLR_HOME%\lib\original-*"
 popd
 
 @REM Any .jar files under the lib directory will be copied to the staged runtime lib tree.

--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -37,7 +37,7 @@ if NOT EXIST "%SPARKCLR_HOME%\samples" mkdir "%SPARKCLR_HOME%\samples"
 pushd "%CMDHOME%\..\scala"
 
 @rem clean the target directory first
-call mvn.cmd clean
+call mvn.cmd %MVN_QUIET% clean
 
 @rem
 @rem Note: Shade-plugin helps creates an uber-package to simplify SparkCLR job submission;
@@ -51,7 +51,7 @@ copy /y pom.xml %temp%\pom.xml.patched
 IF "%APPVEYOR_REPO_TAG%" == "true" (goto :sign)
 
     @rem build the package
-    call mvn.cmd package -Puber-jar
+    call mvn.cmd %MVN_QUIET% package -Puber-jar
     goto :mvndone
 
 :sign
@@ -71,7 +71,7 @@ IF "%APPVEYOR_REPO_TAG%" == "true" (goto :sign)
     gpg2 --list-key
     
     @rem build the package, sign, deploy to maven central
-    call mvn clean deploy -Puber-jar -DdoSign=true -DdoRelease=true
+    call mvn %MVN_QUIET% clean deploy -Puber-jar -DdoSign=true -DdoRelease=true
 
 :mvndone
 

--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -1,8 +1,12 @@
+@setlocal
 @echo OFF
-setlocal
+
+SET CMDHOME=%~dp0
+@REM Remove trailing backslash \
+set CMDHOME=%CMDHOME:~0,-1%
 
 @rem check prerequisites
-call .\localmode\precheck.cmd
+call "%CMDHOME%\localmode\precheck.cmd"
 
 if %precheck% == "bad" (goto :eof)
 
@@ -10,14 +14,10 @@ if %precheck% == "bad" (goto :eof)
 powershell -Command Set-ExecutionPolicy -Scope CurrentUser Unrestricted
 
 @rem download build tools
-pushd %~dp0
+pushd "%CMDHOME%"
 powershell -f localmode\downloadtools.ps1 build
 call tools\updatebuildtoolenv.cmd
 popd
-
-SET CMDHOME=%~dp0
-@REM Remove trailing backslash \
-set CMDHOME=%CMDHOME:~0,-1%
 
 set SPARKCLR_HOME=%CMDHOME%\runtime
 @echo SPARKCLR_HOME=%SPARKCLR_HOME%
@@ -81,9 +81,9 @@ IF "%APPVEYOR_REPO_TAG%" == "true" (goto :sign)
 copy /y %temp%\pom.xml.original pom.xml
 
 if %ERRORLEVEL% NEQ 0 (
-    @echo Build SparkCLR Scala components failed, stop building.
-    popd
-    goto :eof
+  @echo Build SparkCLR Scala components failed, stop building.
+  popd
+  goto :eof
 )
 
 @echo SparkCLR Scala binaries
@@ -109,9 +109,9 @@ call Clean.cmd
 call Build.cmd
 
 if %ERRORLEVEL% NEQ 0 (
-    @echo Build SparkCLR C# components failed, stop building.
-    popd
-    goto :eof
+  @echo Build SparkCLR C# components failed, stop building.
+  popd
+  goto :eof
 )
 
 @echo SparkCLR C# binaries
@@ -130,7 +130,7 @@ popd
 xcopy /e /y "%CMDHOME%\..\scripts"  "%SPARKCLR_HOME%\scripts\"
 
 @echo Make distribution
-pushd %~dp0
+pushd "%CMDHOME%"
 if not exist ".\target" (mkdir .\target)
 
 if not defined ProjectVersion (

--- a/build/Build.cmd
+++ b/build/Build.cmd
@@ -87,9 +87,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 @echo SparkCLR Scala binaries
-copy /y target\*.jar "%SPARKCLR_HOME%\lib\"
-@REM Exclude any original pre-shaded .jar files
-del /q "%SPARKCLR_HOME%\lib\original-*"
+copy /y target\spark*.jar "%SPARKCLR_HOME%\lib\"
 popd
 
 @REM Any .jar files under the lib directory will be copied to the staged runtime lib tree.

--- a/build/build.sh
+++ b/build/build.sh
@@ -38,7 +38,7 @@ then
 	exit 1
 fi
 echo "SparkCLR Scala binaries"
-cp target/*.jar "$SPARKCLR_HOME/lib/"
+cp target/spark*.jar "$SPARKCLR_HOME/lib/"
 popd
 
 # Any .jar files under the lib directory will be copied to the staged runtime lib tree.

--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -56,6 +56,8 @@ powershell -Command Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unre
 @rem download runtime dependencies
 pushd %CMDHOME%
 powershell -f downloadtools.ps1 run !VERBOSE!
+@echo [RunSamples.cmd] UpdateRuntime.cmd
+type ..\tools\updateruntime.cmd
 call ..\tools\updateruntime.cmd
 popd
 
@@ -83,6 +85,7 @@ set SAMPLES_DIR=%SPARKCLR_HOME%\samples
 pushd "%SPARKCLR_HOME%\scripts"
 @echo [RunSamples.cmd] CWD=
 @cd
+@dir /s "%SPARKCLR_HOME%"
 
 if "!USER_EXE!"=="" (
     @echo [RunSamples.cmd] call sparkclr-submit.cmd --exe SparkCLRSamples.exe %SAMPLES_DIR% spark.local.dir %TEMP_DIR% sparkclr.sampledata.loc %SPARKCLR_HOME%\data %*

--- a/build/localmode/RunSamples.cmd
+++ b/build/localmode/RunSamples.cmd
@@ -8,11 +8,6 @@ set CMDHOME=%CMDHOME:~0,-1%
 set VERBOSE=
 set USER_EXE=
 
-set CMDHOME=%~dp0
-
-@REM Remove trailing backslash \
-set CMDHOME=%CMDHOME:~0,-1%
-
 :argsloop
 
 if "%1" == "" (
@@ -54,7 +49,7 @@ set HADOOP_VERSION=2.6
 powershell -Command Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
 
 @rem download runtime dependencies
-pushd %CMDHOME%
+pushd "%CMDHOME%"
 powershell -f downloadtools.ps1 run !VERBOSE!
 @echo [RunSamples.cmd] UpdateRuntime.cmd
 type ..\tools\updateruntime.cmd

--- a/build/localmode/downloadtools.ps1
+++ b/build/localmode/downloadtools.ps1
@@ -213,20 +213,25 @@ function Download-BuildTools
     }
     
     # Apache Maven
-    $mvnCmd = "$toolsDir\apache-maven-3.3.3\bin\mvn.cmd"
+	$mvnVer = "apache-maven-3.3.3"
+    $mvnCmd = "$toolsDir\$mvnVer\bin\mvn.cmd"
     if (!(test-path $mvnCmd))
     {
-        $url = "http://www.us.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
-        $output="$toolsDir\apache-maven-3.3.3-bin.tar.gz"
+        $url = "http://www.us.apache.org/dist/maven/maven-3/3.3.3/binaries/$mvnVer-bin.tar.gz"
+        $output="$toolsDir\$mvnVer-bin.tar.gz"
         Download-File $url $output
         Untar-File $output $toolsDir
+
+        # Add downloaded Mvn to path + env
+        $envStream.WriteLine("set M2_HOME=$toolsDir\$mvnVer");
+        $envStream.WriteLine("set M2=%M2_HOME%\bin");
     }
     else
     {
         Write-Output "[downloadtools.Download-BuildTools] $mvnCmd exists already. No download and extraction needed"
     }
     
-    $mavenBin = "$toolsDir\apache-maven-3.3.3\bin"
+    $mavenBin = "$toolsDir\$mvnVer\bin"
     if (!($path -like "*$mavenBin*"))
     {
         # add maven bin

--- a/build/localmode/precheck.cmd
+++ b/build/localmode/precheck.cmd
@@ -19,6 +19,7 @@ if not exist "%JAVA_HOME%\bin\java.exe" (
 set path=%path%;%JAVA_HOME%\bin
 
 set version=unknown
+@echo VisualStudioVersion = "%VisualStudioVersion%"
 if "%VisualStudioVersion%" == "" ( goto vstudiowarning)
 
 @REM VS 2013 == Version 12; VS 2015 == Version 14
@@ -37,3 +38,6 @@ goto :eof
 @echo. 
 @echo ============================================================================================
 @echo. 
+@echo Environment Variables
+@echo. 
+set

--- a/csharp/Build.cmd
+++ b/csharp/Build.cmd
@@ -15,6 +15,9 @@ SET MSBUILDOPT=/verbosity:minimal
 
 if "%builduri%" == "" set builduri=Build.cmd
 
+cd "%CMDHOME%"
+@cd
+
 set PROJ_NAME=SparkCLR
 set PROJ=%CMDHOME%\%PROJ_NAME%.sln
 
@@ -23,7 +26,7 @@ set PROJ=%CMDHOME%\%PROJ_NAME%.sln
 @echo Restore NuGet packages ===================
 SET STEP=NuGet-Restore
 
-nuget restore
+nuget restore "%PROJ%"
 
 @if ERRORLEVEL 1 GOTO :ErrorStop
 


### PR DESCRIPTION
I have found these changes were required to get SparkCLR building again on my VSO instance, mostly due to problems with mvn settings. 

PR #257 commit 7159d9191f231e6f9e4b527322152d15fa1e2594 helped unmask the VSO build problems, which had been happening for a while.

The main part of the change is this:

- If mvn not already installed, then set M2 env variables from download 
d4310ce4bd243a77872c989b14ba195720aba4d1

This change set also contains a tweak to run mvn in --quiet more on the build servers, because the massive amount of download progress messages in the build log were also causing any build issues to be hard to spot.

- Run Maven in `--quiet` mode to avoid all the download progress messages in the build server logs.
c3eaa3afe31371a7d1fc5144f1e5d184c4116368

The other parts of this change set are minor diagnosability tweaks and/or clean-ups.

I have left the commits as separate micro-changes so that it is easier to see what each step does, but let me know if you prefer squash before merge.