### PR TITLE
Fix Pi example can't run in yarn-cluster mode issue

### DIFF
--- a/examples/pi/Program.cs
+++ b/examples/pi/Program.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Spark.CSharp.Examples
             var success = true;
 
             SparkContext = CreateSparkContext();
-            SparkContext.SetCheckpointDir(Path.GetTempPath());
 
             var stopWatch = Stopwatch.StartNew();
             var clockStart = stopWatch.Elapsed;


### PR DESCRIPTION
Checkpoint directory needs to be a HDFS path when the deploy mode is `yarn-cluster`. Remove `SparkContext.SetCheckpointDir(Path.GetTempPath());` to make `Pi` example run well in `yarn-cluster` mode.