### PR TITLE
Improve RDDCheckpointSample and add validations

### DIFF
--- a/csharp/Samples/Microsoft.Spark.CSharp/RDDSamples.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/RDDSamples.cs
@@ -18,8 +18,13 @@ namespace Microsoft.Spark.CSharp.Samples
             var rdd = SparkCLRSamples.SparkContext.Parallelize(Enumerable.Range(0, 100), 4);
             rdd.Cache();
             rdd.Unpersist();
+            Assert.AreEqual(false, rdd.IsCheckpointed);
             rdd.Checkpoint();
+            Assert.AreEqual(false, rdd.IsCheckpointed);
+            rdd.Count();
             Console.WriteLine(rdd.IsCheckpointed);
+            // rdd.IsCheckpointed is set to true immediately first action invoked on this RDD has completed
+            Assert.AreEqual(true, rdd.IsCheckpointed);
         }
 
         [Sample]


### PR DESCRIPTION
In current `RDDCheckpointSample`, `Console.WriteLine(rdd.IsCheckpointed)` always print out `false`.
Call `Count()` action of the RDD to make sure `doCheckpoint` method invoked and `rdd.IsCheckpointed` returns true.