### PR TITLE
Add '--checkpointdir' to explicity specify checkpoint directory when run samples

### DIFF
--- a/csharp/Samples/Microsoft.Spark.CSharp/CommandlineArgumentProcessor.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/CommandlineArgumentProcessor.cs
@@ -59,6 +59,11 @@ namespace Microsoft.Spark.CSharp.Samples
                 {
                     configuration.IsValidationEnabled = true;
                 }
+                else if (args[i].Equals("sparkclr.samples.checkpointdir", StringComparison.InvariantCultureIgnoreCase)
+                    || args[i].Equals("--checkpointdir", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    configuration.CheckpointDir = args[i + 1];
+                }
                 else if (args[i].Equals("sparkclr.dryrun", StringComparison.InvariantCultureIgnoreCase)
                     || args[i].Equals("--dryrun", StringComparison.InvariantCultureIgnoreCase))
                 {

--- a/csharp/Samples/Microsoft.Spark.CSharp/Configuration.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Configuration.cs
@@ -62,6 +62,12 @@ namespace Microsoft.Spark.CSharp.Samples
             set;
         }
 
+        public string CheckpointDir
+        {
+            get; 
+            set;
+        }
+
         public string GetInputDataPath(string fileName)
         {
             if (SampleDataLocation.StartsWith("hdfs://"))

--- a/csharp/Samples/Microsoft.Spark.CSharp/Program.cs
+++ b/csharp/Samples/Microsoft.Spark.CSharp/Program.cs
@@ -34,7 +34,12 @@ namespace Microsoft.Spark.CSharp.Samples
             else
             {
                 SparkContext = CreateSparkContext();
-                SparkContext.SetCheckpointDir(Path.GetTempPath());
+                if (string.IsNullOrEmpty(Configuration.CheckpointDir))
+                {
+                    Configuration.CheckpointDir = Path.GetTempPath();
+                }
+                ConsoleWriteLine("Set checkpoint directory to: " + Configuration.CheckpointDir);
+                SparkContext.SetCheckpointDir(Configuration.CheckpointDir);
 
                 status = SamplesRunner.RunSamples();
 


### PR DESCRIPTION
* Currently in SparkCLR samples checkpoint directory is set to a local temp path.
* Samples breaks when it is running in yarn mode.
* Add new parameter `--checkpointdir` to explicitly specify a checkpoint directory(HDFS path for yarn mode).
* To be backward compatible, checkpoint directory is set to a local temp path when `--checkpointdir` is not specified.